### PR TITLE
Submitting and Responding to Reports

### DIFF
--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -10,7 +10,7 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useNostrPublish } from "@/hooks/useNostrPublish";
 import { useBannedUsers } from "@/hooks/useBannedUsers";
 import { toast } from "sonner";
-import { MessageSquare, Share2, CheckCircle, XCircle, Shield, MoreHorizontal, Ban, ChevronDown, ChevronUp } from "lucide-react";
+import { MessageSquare, Share2, CheckCircle, XCircle, Shield, MoreHorizontal, Ban, ChevronDown, ChevronUp, Flag } from "lucide-react";
 import { EmojiReactionButton } from "@/components/EmojiReactionButton";
 import { NostrEvent } from "@nostrify/nostrify";
 import { nip19 } from 'nostr-tools';
@@ -18,6 +18,7 @@ import { NoteContent } from "../NoteContent";
 import { Link } from "react-router-dom";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 import { ReplyList } from "./ReplyList";
+import { ReportDialog } from "./ReportDialog";
 import { 
   DropdownMenu, 
   DropdownMenuContent, 
@@ -378,6 +379,7 @@ function PostItem({ post, communityId, isApproved, isModerator }: PostItemProps)
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false);
   const [isBanDialogOpen, setIsBanDialogOpen] = useState(false);
   const [showReplies, setShowReplies] = useState(false);
+  const [isReportDialogOpen, setIsReportDialogOpen] = useState(false);
 
   const metadata = author.data?.metadata;
   const displayName = metadata?.name || post.pubkey.slice(0, 12);
@@ -562,6 +564,17 @@ function PostItem({ post, communityId, isApproved, isModerator }: PostItemProps)
             <Share2 className="h-3.5 w-3.5 mr-1" />
             <span className="text-xs">Share</span>
           </Button>
+          {user && user.pubkey !== post.pubkey && (
+            <Button 
+              variant="ghost" 
+              size="sm" 
+              className="text-muted-foreground hover:text-foreground flex items-center h-7 px-1.5 ml-auto"
+              onClick={() => setIsReportDialogOpen(true)}
+            >
+              <Flag className="h-3.5 w-3.5 mr-1" />
+              <span className="text-xs">Report</span>
+            </Button>
+          )}
         </div>
         
         {showReplies && (
@@ -574,6 +587,16 @@ function PostItem({ post, communityId, isApproved, isModerator }: PostItemProps)
           </div>
         )}
       </div>
+      
+      {/* Report Dialog */}
+      <ReportDialog
+        isOpen={isReportDialogOpen}
+        onClose={() => setIsReportDialogOpen(false)}
+        pubkey={post.pubkey}
+        eventId={post.id}
+        communityId={communityId}
+        contentPreview={post.content}
+      />
     </div>
   );
 }

--- a/src/components/groups/ReportDialog.tsx
+++ b/src/components/groups/ReportDialog.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { useReportContent, ReportType } from "@/hooks/useReportContent";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { AlertTriangle } from "lucide-react";
+
+interface ReportDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  pubkey: string;
+  eventId?: string;
+  communityId?: string;
+  contentPreview?: string;
+}
+
+export function ReportDialog({
+  isOpen,
+  onClose,
+  pubkey,
+  eventId,
+  communityId,
+  contentPreview,
+}: ReportDialogProps) {
+  const { user } = useCurrentUser();
+  const { reportContent, isPending } = useReportContent();
+  const [reportType, setReportType] = useState<ReportType>("other");
+  const [reason, setReason] = useState("");
+
+  const handleSubmit = async () => {
+    if (!user) return;
+
+    try {
+      await reportContent({
+        pubkey,
+        eventId,
+        communityId,
+        reportType,
+        reason,
+      });
+      
+      // Reset form and close dialog
+      setReportType("other");
+      setReason("");
+      onClose();
+    } catch (error) {
+      // Error is handled in the hook
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Report Content
+          </DialogTitle>
+          <DialogDescription>
+            Report this content to the group moderators. Please provide details about why you're reporting it.
+          </DialogDescription>
+        </DialogHeader>
+
+        {contentPreview && (
+          <div className="bg-muted p-3 rounded-md text-sm mb-4 max-h-24 overflow-y-auto">
+            <p className="font-medium text-xs mb-1 text-muted-foreground">Content being reported:</p>
+            <p className="line-clamp-3">{contentPreview}</p>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="report-type">Report reason</Label>
+            <RadioGroup
+              id="report-type"
+              value={reportType}
+              onValueChange={(value) => setReportType(value as ReportType)}
+              className="grid grid-cols-2 gap-2"
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="nudity" id="nudity" />
+                <Label htmlFor="nudity">Nudity/Sexual content</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="malware" id="malware" />
+                <Label htmlFor="malware">Malware/Scam</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="profanity" id="profanity" />
+                <Label htmlFor="profanity">Profanity/Hate speech</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="illegal" id="illegal" />
+                <Label htmlFor="illegal">Illegal content</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="spam" id="spam" />
+                <Label htmlFor="spam">Spam</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="impersonation" id="impersonation" />
+                <Label htmlFor="impersonation">Impersonation</Label>
+              </div>
+              <div className="flex items-center space-x-2 col-span-2">
+                <RadioGroupItem value="other" id="other" />
+                <Label htmlFor="other">Other</Label>
+              </div>
+            </RadioGroup>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="report-details">Additional details</Label>
+            <Textarea
+              id="report-details"
+              placeholder="Please provide more information about why you're reporting this content..."
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={4}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isPending || !user}>
+            {isPending ? "Submitting..." : "Submit Report"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/groups/ReportsList.tsx
+++ b/src/components/groups/ReportsList.tsx
@@ -10,7 +10,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Link } from "react-router-dom";
-import { AlertTriangle, CheckCircle, XCircle, UserX, Ban, MoreHorizontal, User } from "lucide-react";
+import { AlertTriangle, CheckCircle, XCircle, UserX, Ban, MoreHorizontal, User, Inbox as InboxIcon, Archive as ArchiveIcon } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import {
   DropdownMenu,
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface ReportsListProps {
   communityId: string;
@@ -43,6 +44,7 @@ export function ReportsList({ communityId }: ReportsListProps) {
   const [actionType, setActionType] = useState<ModeratorAction | null>(null);
   const [actionReason, setActionReason] = useState("");
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("open");
 
   const handleAction = async () => {
     if (!selectedReport || !actionType) return;
@@ -116,15 +118,74 @@ export function ReportsList({ communityId }: ReportsListProps) {
     );
   }
 
+  // Separate reports into open and closed
+  const openReports = reports.filter(report => !report.isClosed);
+  const closedReports = reports.filter(report => report.isClosed);
+
+  // Count for badges
+  const openCount = openReports.length;
+  const closedCount = closedReports.length;
+
   return (
     <div className="space-y-4">
-      {reports.map((report) => (
-        <ReportItem 
-          key={report.id} 
-          report={report} 
-          onAction={(action) => openActionDialog(report, action)} 
-        />
-      ))}
+      <Tabs defaultValue="open" value={activeTab} onValueChange={setActiveTab} className="w-full">
+        <TabsList className="grid grid-cols-2 mb-4">
+          <TabsTrigger value="open" className="flex items-center gap-2">
+            <InboxIcon className="h-4 w-4" /> 
+            Open Reports
+            {openCount > 0 && (
+              <Badge variant="secondary" className="ml-1 bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                {openCount}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="closed" className="flex items-center gap-2">
+            <ArchiveIcon className="h-4 w-4" /> 
+            Closed Reports
+            {closedCount > 0 && (
+              <Badge variant="secondary" className="ml-1">
+                {closedCount}
+              </Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+        
+        <TabsContent value="open" className="space-y-4">
+          {openReports.length === 0 ? (
+            <Card className="p-8 text-center">
+              <CheckCircle className="h-12 w-12 mx-auto mb-4 text-green-500 opacity-50" />
+              <p className="text-muted-foreground mb-2">No open reports</p>
+              <p className="text-sm">All reports have been handled. Great job!</p>
+            </Card>
+          ) : (
+            openReports.map((report) => (
+              <ReportItem 
+                key={report.id} 
+                report={report} 
+                onAction={(action) => openActionDialog(report, action)} 
+              />
+            ))
+          )}
+        </TabsContent>
+        
+        <TabsContent value="closed" className="space-y-4">
+          {closedReports.length === 0 ? (
+            <Card className="p-8 text-center">
+              <ArchiveIcon className="h-12 w-12 mx-auto mb-4 text-muted-foreground opacity-50" />
+              <p className="text-muted-foreground mb-2">No closed reports</p>
+              <p className="text-sm">Closed reports will appear here after you take action on them.</p>
+            </Card>
+          ) : (
+            closedReports.map((report) => (
+              <ReportItem 
+                key={report.id} 
+                report={report} 
+                onAction={(action) => openActionDialog(report, action)} 
+              />
+            ))
+          )}
+        </TabsContent>
+      </Tabs>
 
       <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <AlertDialogContent>

--- a/src/components/groups/ReportsList.tsx
+++ b/src/components/groups/ReportsList.tsx
@@ -1,0 +1,299 @@
+import { useState } from "react";
+import { useGroupReports, Report } from "@/hooks/useGroupReports";
+import { useReportActions, ModeratorAction } from "@/hooks/useReportActions";
+import { useAuthor } from "@/hooks/useAuthor";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Link } from "react-router-dom";
+import { AlertTriangle, CheckCircle, XCircle, UserX, Ban, MoreHorizontal } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+
+interface ReportsListProps {
+  communityId: string;
+}
+
+export function ReportsList({ communityId }: ReportsListProps) {
+  const { data: reports, isLoading, refetch } = useGroupReports(communityId);
+  const { handleReportAction, isPending } = useReportActions();
+  const [selectedReport, setSelectedReport] = useState<Report | null>(null);
+  const [actionType, setActionType] = useState<ModeratorAction | null>(null);
+  const [actionReason, setActionReason] = useState("");
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleAction = async () => {
+    if (!selectedReport || !actionType) return;
+
+    try {
+      await handleReportAction({
+        reportId: selectedReport.id,
+        communityId,
+        pubkey: selectedReport.reportedPubkey,
+        eventId: selectedReport.reportedEventId,
+        action: actionType,
+        reason: actionReason,
+      });
+      
+      // Reset state and close dialog
+      setSelectedReport(null);
+      setActionType(null);
+      setActionReason("");
+      setIsDialogOpen(false);
+      
+      // Refresh the reports list
+      refetch();
+    } catch (error) {
+      // Error is handled in the hook
+    }
+  };
+
+  const openActionDialog = (report: Report, action: ModeratorAction) => {
+    setSelectedReport(report);
+    setActionType(action);
+    setIsDialogOpen(true);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-2">
+              <Skeleton className="h-4 w-32 mb-2" />
+              <Skeleton className="h-3 w-24" />
+            </CardHeader>
+            <CardContent className="pb-2">
+              <div className="flex items-center gap-2 mb-3">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+              <Skeleton className="h-4 w-full mb-2" />
+              <Skeleton className="h-4 w-2/3" />
+            </CardContent>
+            <CardFooter>
+              <div className="flex gap-2">
+                <Skeleton className="h-8 w-20" />
+                <Skeleton className="h-8 w-20" />
+                <Skeleton className="h-8 w-20" />
+              </div>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (!reports || reports.length === 0) {
+    return (
+      <Card className="p-8 text-center">
+        <CheckCircle className="h-12 w-12 mx-auto mb-4 text-green-500 opacity-50" />
+        <p className="text-muted-foreground mb-2">No reports in this group</p>
+        <p className="text-sm">When users report content, it will appear here for review.</p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {reports.map((report) => (
+        <ReportItem 
+          key={report.id} 
+          report={report} 
+          onAction={(action) => openActionDialog(report, action)} 
+        />
+      ))}
+
+      <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {actionType === "remove_content" && "Remove Content"}
+              {actionType === "remove_user" && "Remove User"}
+              {actionType === "ban_user" && "Ban User"}
+              {actionType === "no_action" && "Take No Action"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {actionType === "remove_content" && 
+                "This will remove the reported content from the group. The content will no longer be visible to members."}
+              {actionType === "remove_user" && 
+                "This will remove the user from the approved members list. They will need to request to join again."}
+              {actionType === "ban_user" && 
+                "This will ban the user from the group. All their content will be hidden and they won't be able to post."}
+              {actionType === "no_action" && 
+                "This will mark the report as reviewed with no action taken. The report will be archived."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          
+          <div className="py-2">
+            <Label htmlFor="action-reason">Reason (optional)</Label>
+            <Textarea
+              id="action-reason"
+              placeholder="Add a reason for this action..."
+              value={actionReason}
+              onChange={(e) => setActionReason(e.target.value)}
+              className="mt-2"
+            />
+          </div>
+          
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction 
+              onClick={handleAction} 
+              disabled={isPending}
+              className={actionType === "ban_user" || actionType === "remove_content" ? 
+                "bg-red-600 hover:bg-red-700" : undefined}
+            >
+              {isPending ? "Processing..." : "Confirm"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface ReportItemProps {
+  report: Report;
+  onAction: (action: ModeratorAction) => void;
+}
+
+function ReportItem({ report, onAction }: ReportItemProps) {
+  const reporterAuthor = useAuthor(report.pubkey);
+  const reportedAuthor = useAuthor(report.reportedPubkey);
+  
+  const reporterName = reporterAuthor.data?.metadata?.name || report.pubkey.slice(0, 8);
+  const reporterImage = reporterAuthor.data?.metadata?.picture;
+  
+  const reportedName = reportedAuthor.data?.metadata?.name || report.reportedPubkey.slice(0, 8);
+  const reportedImage = reportedAuthor.data?.metadata?.picture;
+  
+  const reportTime = formatDistanceToNow(new Date(report.created_at * 1000), { addSuffix: true });
+  
+  const getReportTypeBadge = () => {
+    switch (report.reportType) {
+      case "nudity":
+        return <Badge variant="destructive">Nudity</Badge>;
+      case "malware":
+        return <Badge variant="destructive">Malware/Scam</Badge>;
+      case "profanity":
+        return <Badge variant="destructive">Profanity</Badge>;
+      case "illegal":
+        return <Badge variant="destructive">Illegal Content</Badge>;
+      case "spam":
+        return <Badge>Spam</Badge>;
+      case "impersonation":
+        return <Badge variant="destructive">Impersonation</Badge>;
+      default:
+        return <Badge variant="outline">Other</Badge>;
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-500" />
+            Report {getReportTypeBadge()}
+          </CardTitle>
+          <span className="text-xs text-muted-foreground">{reportTime}</span>
+        </div>
+        <CardDescription>
+          Reported by <Link to={`/profile/${report.pubkey}`} className="underline">{reporterName}</Link>
+        </CardDescription>
+      </CardHeader>
+      
+      <CardContent className="pb-2">
+        <div className="flex items-center gap-3 mb-3 p-2 bg-muted/50 rounded-md">
+          <Link to={`/profile/${report.reportedPubkey}`}>
+            <Avatar className="h-8 w-8">
+              <AvatarImage src={reportedImage} />
+              <AvatarFallback>{reportedName.slice(0, 2).toUpperCase()}</AvatarFallback>
+            </Avatar>
+          </Link>
+          <div>
+            <Link to={`/profile/${report.reportedPubkey}`} className="font-medium text-sm hover:underline">
+              {reportedName}
+            </Link>
+            <p className="text-xs text-muted-foreground">Reported user</p>
+          </div>
+        </div>
+        
+        {report.reason && (
+          <div className="mb-3">
+            <p className="text-sm font-medium mb-1">Report reason:</p>
+            <p className="text-sm bg-muted/30 p-2 rounded-md">{report.reason}</p>
+          </div>
+        )}
+        
+        {report.reportedEventId && (
+          <div className="text-xs text-muted-foreground">
+            <span>Reported content ID: </span>
+            <code className="bg-muted px-1 py-0.5 rounded">{report.reportedEventId.slice(0, 10)}...{report.reportedEventId.slice(-4)}</code>
+          </div>
+        )}
+      </CardContent>
+      
+      <CardFooter className="pt-2 flex flex-wrap gap-2">
+        <Button 
+          size="sm" 
+          variant="outline" 
+          className="text-green-600" 
+          onClick={() => onAction("no_action")}
+        >
+          <CheckCircle className="h-4 w-4 mr-1" /> No Action
+        </Button>
+        
+        {report.reportedEventId && (
+          <Button 
+            size="sm" 
+            variant="outline" 
+            className="text-amber-600" 
+            onClick={() => onAction("remove_content")}
+          >
+            <XCircle className="h-4 w-4 mr-1" /> Remove Content
+          </Button>
+        )}
+        
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button size="sm" variant="outline">
+              <MoreHorizontal className="h-4 w-4 mr-1" /> More Actions
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onAction("remove_user")}>
+              <UserX className="h-4 w-4 mr-2" /> Remove User
+            </DropdownMenuItem>
+            <DropdownMenuItem 
+              onClick={() => onAction("ban_user")}
+              className="text-red-600"
+            >
+              <Ban className="h-4 w-4 mr-2" /> Ban User
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/groups/ReportsList.tsx
+++ b/src/components/groups/ReportsList.tsx
@@ -149,6 +149,11 @@ export function ReportsList({ communityId }: ReportsListProps) {
             <div className="border border-muted rounded-md p-3 bg-muted/20 my-2">
               <p className="text-sm font-medium mb-1">Content to be removed:</p>
               <PostContentPreview eventId={selectedReport.reportedEventId} />
+              <div className="mt-2 text-xs text-muted-foreground">
+                <p>This will create a kind 4551 removal event that will hide this content from the community.</p>
+                <p className="mt-1">Post ID: <code className="bg-muted px-1 py-0.5 rounded">{selectedReport.reportedEventId.slice(0, 8)}...{selectedReport.reportedEventId.slice(-4)}</code></p>
+                <p>Author: <code className="bg-muted px-1 py-0.5 rounded">{selectedReport.reportedPubkey.slice(0, 8)}...{selectedReport.reportedPubkey.slice(-4)}</code></p>
+              </div>
             </div>
           )}
           

--- a/src/components/groups/ReportsList.tsx
+++ b/src/components/groups/ReportsList.tsx
@@ -172,7 +172,7 @@ export function ReportsList({ communityId }: ReportsListProps) {
                 ) : approvedMembers?.includes(selectedReport.reportedPubkey) ? (
                   <p className="mt-1">User is currently in the approved members list.</p>
                 ) : (
-                  <p className="mt-1 text-amber-600">Note: This user is not currently in the approved members list.</p>
+                  <p className="mt-1 text-amber-600 font-medium">Warning: This user is not currently in the approved members list. No action will be taken.</p>
                 )}
                 <p className="mt-1">User ID: <code className="bg-muted px-1 py-0.5 rounded">{selectedReport.reportedPubkey.slice(0, 8)}...{selectedReport.reportedPubkey.slice(-4)}</code></p>
               </div>

--- a/src/components/groups/ReportsList.tsx
+++ b/src/components/groups/ReportsList.tsx
@@ -294,6 +294,13 @@ function ReportItem({ report, onAction }: ReportItemProps) {
         return <Badge variant="outline">Other</Badge>;
     }
   };
+  
+  const getStatusBadge = () => {
+    if (report.isClosed) {
+      return <Badge variant="outline" className="bg-muted text-muted-foreground">Closed</Badge>;
+    }
+    return <Badge variant="secondary" className="bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">Open</Badge>;
+  };
 
   return (
     <Card>
@@ -301,7 +308,7 @@ function ReportItem({ report, onAction }: ReportItemProps) {
         <div className="flex items-center justify-between">
           <CardTitle className="text-base flex items-center gap-2">
             <AlertTriangle className="h-4 w-4 text-amber-500" />
-            Report {getReportTypeBadge()}
+            Report {getReportTypeBadge()} {getStatusBadge()}
           </CardTitle>
           <span className="text-xs text-muted-foreground">{reportTime}</span>
         </div>
@@ -333,6 +340,18 @@ function ReportItem({ report, onAction }: ReportItemProps) {
           </div>
         )}
         
+        {report.isClosed && (
+          <div className="mb-3 border border-muted p-2 rounded-md bg-muted/20">
+            <p className="text-sm font-medium mb-1 flex items-center gap-1">
+              <CheckCircle className="h-4 w-4 text-green-500" /> 
+              Resolution: <span className="font-normal">{report.resolutionAction}</span>
+            </p>
+            {report.resolutionReason && (
+              <p className="text-sm mt-1">{report.resolutionReason}</p>
+            )}
+          </div>
+        )}
+        
         {report.reportedEventId && (
           <>
             {isLoadingPost ? (
@@ -361,44 +380,50 @@ function ReportItem({ report, onAction }: ReportItemProps) {
       </CardContent>
       
       <CardFooter className="pt-2 flex flex-wrap gap-2">
-        <Button 
-          size="sm" 
-          variant="outline" 
-          className="text-green-600" 
-          onClick={() => onAction("no_action")}
-        >
-          <CheckCircle className="h-4 w-4 mr-1" /> No Action
-        </Button>
-        
-        {report.reportedEventId && (
-          <Button 
-            size="sm" 
-            variant="outline" 
-            className="text-amber-600" 
-            onClick={() => onAction("remove_content")}
-          >
-            <XCircle className="h-4 w-4 mr-1" /> Remove Content
-          </Button>
-        )}
-        
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button size="sm" variant="outline">
-              <MoreHorizontal className="h-4 w-4 mr-1" /> More Actions
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => onAction("remove_user")}>
-              <UserX className="h-4 w-4 mr-2" /> Remove User
-            </DropdownMenuItem>
-            <DropdownMenuItem 
-              onClick={() => onAction("ban_user")}
-              className="text-red-600"
+        {!report.isClosed ? (
+          <>
+            <Button 
+              size="sm" 
+              variant="outline" 
+              className="text-green-600" 
+              onClick={() => onAction("no_action")}
             >
-              <Ban className="h-4 w-4 mr-2" /> Ban User
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <CheckCircle className="h-4 w-4 mr-1" /> No Action
+            </Button>
+            
+            {report.reportedEventId && (
+              <Button 
+                size="sm" 
+                variant="outline" 
+                className="text-amber-600" 
+                onClick={() => onAction("remove_content")}
+              >
+                <XCircle className="h-4 w-4 mr-1" /> Remove Content
+              </Button>
+            )}
+            
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="sm" variant="outline">
+                  <MoreHorizontal className="h-4 w-4 mr-1" /> More Actions
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => onAction("remove_user")}>
+                  <UserX className="h-4 w-4 mr-2" /> Remove User
+                </DropdownMenuItem>
+                <DropdownMenuItem 
+                  onClick={() => onAction("ban_user")}
+                  className="text-red-600"
+                >
+                  <Ban className="h-4 w-4 mr-2" /> Ban User
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">This report has been resolved.</p>
+        )}
       </CardFooter>
     </Card>
   );

--- a/src/hooks/useBannedUsers.ts
+++ b/src/hooks/useBannedUsers.ts
@@ -22,11 +22,18 @@ export function useBannedUsers(communityId?: string) {
     queryFn: async (c) => {
       const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
       
-      const events = await nostr.query([{ 
+      // Create the filter object
+      const filter: Record<string, any> = {
         kinds: [14552],
-        "#a": [communityId],
         limit: 50,
-      }], { signal });
+      };
+      
+      // Only add the community filter if communityId is defined
+      if (communityId) {
+        filter["#a"] = [communityId];
+      }
+      
+      const events = await nostr.query([filter], { signal });
       
       return events;
     },

--- a/src/hooks/useGroupReports.ts
+++ b/src/hooks/useGroupReports.ts
@@ -1,0 +1,51 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { NostrEvent } from "@nostrify/nostrify";
+
+export interface Report extends NostrEvent {
+  reportType: string;
+  reportedPubkey: string;
+  reportedEventId?: string;
+  reason: string;
+}
+
+export function useGroupReports(communityId: string) {
+  const { nostr } = useNostr();
+
+  return useQuery({
+    queryKey: ["group-reports", communityId],
+    queryFn: async (c) => {
+      if (!communityId) return [];
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Query for reports that have the community's a-tag
+      const reports = await nostr.query([{
+        kinds: [1984],
+        "#a": [communityId],
+        limit: 100,
+      }], { signal });
+
+      // Process the reports to extract relevant information
+      return reports.map(report => {
+        const pTag = report.tags.find(tag => tag[0] === "p");
+        const eTag = report.tags.find(tag => tag[0] === "e");
+        
+        const reportType = pTag && pTag[2] ? pTag[2] : 
+                          (eTag && eTag[2] ? eTag[2] : "other");
+        
+        const reportedPubkey = pTag ? pTag[1] : "";
+        const reportedEventId = eTag ? eTag[1] : undefined;
+        
+        return {
+          ...report,
+          reportType,
+          reportedPubkey,
+          reportedEventId,
+          reason: report.content
+        } as Report;
+      });
+    },
+    enabled: !!nostr && !!communityId,
+  });
+}

--- a/src/hooks/usePostById.ts
+++ b/src/hooks/usePostById.ts
@@ -1,0 +1,29 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { NostrEvent } from "@nostrify/nostrify";
+
+/**
+ * Hook to fetch a post by its ID
+ * @param eventId The ID of the post to fetch
+ */
+export function usePostById(eventId?: string) {
+  const { nostr } = useNostr();
+
+  return useQuery({
+    queryKey: ["post", eventId],
+    queryFn: async (c) => {
+      if (!eventId) return null;
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Query for the specific event by ID
+      const events = await nostr.query([{
+        ids: [eventId],
+        limit: 1,
+      }], { signal });
+
+      return events.length > 0 ? events[0] : null;
+    },
+    enabled: !!nostr && !!eventId,
+  });
+}

--- a/src/hooks/useReportActions.ts
+++ b/src/hooks/useReportActions.ts
@@ -1,0 +1,105 @@
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { toast } from "sonner";
+import { useBannedUsers } from "@/hooks/useBannedUsers";
+
+export type ModeratorAction = "remove_content" | "remove_user" | "ban_user" | "no_action";
+
+export interface ReportActionOptions {
+  reportId: string;
+  communityId: string;
+  pubkey: string;
+  eventId?: string;
+  action: ModeratorAction;
+  reason?: string;
+}
+
+export function useReportActions() {
+  const { mutateAsync: publishEvent, isPending } = useNostrPublish({
+    invalidateQueries: [
+      { queryKey: ["group-reports"] },
+      { queryKey: ["approved-posts"] },
+      { queryKey: ["pending-posts"] }
+    ]
+  });
+  const { user } = useCurrentUser();
+  // We'll initialize the hook with the communityId from the options
+  const { banUser } = useBannedUsers(options.communityId);
+
+  const handleReportAction = async (options: ReportActionOptions) => {
+    if (!user) {
+      toast.error("You must be logged in to take action on reports");
+      throw new Error("User not logged in");
+    }
+
+    const { reportId, communityId, pubkey, eventId, action, reason } = options;
+
+    try {
+      // Mark the report as handled
+      await publishEvent({
+        kind: 1985, // Using kind 1985 (Label) to mark the report as handled
+        tags: [
+          ["e", reportId],
+          ["a", communityId],
+          ["l", `report-action:${action}`],
+          ["L", "chorus.report.action"]
+        ],
+        content: reason || `Action taken: ${action}`,
+      });
+
+      // Take the appropriate action based on moderator decision
+      switch (action) {
+        case "remove_content":
+          if (eventId) {
+            await publishEvent({
+              kind: 4551, // Remove post
+              tags: [
+                ["a", communityId], 
+                ["e", eventId], 
+                ["p", pubkey], 
+                ["k", "1"] // Assuming it's a kind 1 post
+              ],
+              content: JSON.stringify({ 
+                reason: reason || "Removed based on report", 
+                timestamp: Date.now() 
+              }),
+            });
+          }
+          break;
+          
+        case "remove_user":
+          // Remove user from approved members list
+          await publishEvent({
+            kind: 14550, // Approved members list
+            tags: [
+              ["a", communityId],
+              ["remove", pubkey]
+            ],
+            content: "Removed user based on report",
+          });
+          break;
+          
+        case "ban_user":
+          // Ban the user
+          await banUser(pubkey, communityId);
+          break;
+          
+        case "no_action":
+          // No additional action needed
+          break;
+      }
+
+      toast.success("Action taken successfully");
+      return true;
+    } catch (error) {
+      console.error("Error taking action on report:", error);
+      toast.error("Failed to take action. Please try again.");
+      throw error;
+    }
+  };
+
+  return {
+    handleReportAction,
+    isPending
+  };
+}

--- a/src/hooks/useReportActions.ts
+++ b/src/hooks/useReportActions.ts
@@ -23,8 +23,8 @@ export function useReportActions() {
     ]
   });
   const { user } = useCurrentUser();
-  // We'll initialize the hook with the communityId from the options
-  const { banUser } = useBannedUsers(options.communityId);
+  // We'll initialize the banUser function inside handleReportAction
+  const { banUser } = useBannedUsers();
 
   const handleReportAction = async (options: ReportActionOptions) => {
     if (!user) {
@@ -80,7 +80,7 @@ export function useReportActions() {
           break;
           
         case "ban_user":
-          // Ban the user
+          // Ban the user with the specific communityId
           await banUser(pubkey, communityId);
           break;
           

--- a/src/hooks/useReportActions.ts
+++ b/src/hooks/useReportActions.ts
@@ -119,7 +119,7 @@ export function useReportActions() {
           
           if (result.success) {
             if (result.message === "User is not in the approved members list") {
-              toast.info("User was already not in the approved members list");
+              toast.warning("User was not found in the approved members list");
             } else {
               toast.success("User removed from approved members list");
             }

--- a/src/hooks/useReportContent.ts
+++ b/src/hooks/useReportContent.ts
@@ -1,0 +1,59 @@
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { toast } from "sonner";
+
+export type ReportType = "nudity" | "malware" | "profanity" | "illegal" | "spam" | "impersonation" | "other";
+
+export interface ReportOptions {
+  pubkey: string;
+  eventId?: string;
+  communityId?: string;
+  reportType: ReportType;
+  reason: string;
+}
+
+export function useReportContent() {
+  const { mutateAsync: publishEvent, isPending } = useNostrPublish();
+  const { user } = useCurrentUser();
+
+  const reportContent = async (options: ReportOptions) => {
+    if (!user) {
+      toast.error("You must be logged in to report content");
+      throw new Error("User not logged in");
+    }
+
+    const { pubkey, eventId, communityId, reportType, reason } = options;
+
+    const tags: string[][] = [
+      ["p", pubkey, reportType]
+    ];
+
+    if (eventId) {
+      tags.push(["e", eventId, reportType]);
+    }
+
+    if (communityId) {
+      tags.push(["a", communityId]);
+    }
+
+    try {
+      await publishEvent({
+        kind: 1984,
+        tags,
+        content: reason || "",
+      });
+
+      toast.success("Report submitted successfully");
+      return true;
+    } catch (error) {
+      console.error("Error reporting content:", error);
+      toast.error("Failed to submit report. Please try again.");
+      throw error;
+    }
+  };
+
+  return {
+    reportContent,
+    isPending
+  };
+}

--- a/src/hooks/useUpdateApprovedMembers.ts
+++ b/src/hooks/useUpdateApprovedMembers.ts
@@ -1,0 +1,107 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { NostrEvent } from "@nostrify/nostrify";
+
+/**
+ * Hook to update the approved members list for a community
+ */
+export function useUpdateApprovedMembers() {
+  const { nostr } = useNostr();
+  const queryClient = useQueryClient();
+  const { mutateAsync: publishEvent, isPending } = useNostrPublish({
+    invalidateQueries: [
+      { queryKey: ["approved-members-list"] },
+      { queryKey: ["approved-posts"] },
+      { queryKey: ["pending-posts"] }
+    ]
+  });
+
+  /**
+   * Fetch the current approved members list for a community
+   * @param communityId The community ID
+   * @returns Array of approved member pubkeys
+   */
+  const fetchApprovedMembers = async (communityId: string): Promise<string[]> => {
+    try {
+      const events = await nostr.query([{ 
+        kinds: [14550],
+        "#a": [communityId],
+        limit: 10,
+      }], { signal: AbortSignal.timeout(5000) });
+      
+      if (events.length === 0) {
+        return [];
+      }
+      
+      // Sort by created_at to get the most recent event
+      const sortedEvents = [...events].sort((a, b) => b.created_at - a.created_at);
+      const latestEvent = sortedEvents[0];
+      
+      // Extract approved members pubkeys
+      return latestEvent.tags
+        .filter(tag => tag[0] === "p")
+        .map(tag => tag[1]);
+    } catch (error) {
+      console.error("Error fetching approved members:", error);
+      throw new Error("Failed to fetch approved members list");
+    }
+  };
+
+  /**
+   * Remove a user from the approved members list
+   * @param pubkey The pubkey of the user to remove
+   * @param communityId The community ID
+   * @returns Object with success status and message
+   */
+  const removeFromApprovedList = async (pubkey: string, communityId: string): Promise<{ success: boolean; message: string }> => {
+    try {
+      // Fetch current approved members
+      const currentApprovedMembers = await fetchApprovedMembers(communityId);
+      
+      // Check if the user is in the approved list
+      if (!currentApprovedMembers.includes(pubkey)) {
+        return { 
+          success: true, 
+          message: "User is not in the approved members list" 
+        };
+      }
+      
+      // Create a new list without the user
+      const updatedApprovedMembers = currentApprovedMembers.filter(p => p !== pubkey);
+      
+      // Create tags for the updated list
+      const tags = [
+        ["a", communityId],
+        ...updatedApprovedMembers.map(p => ["p", p])
+      ];
+      
+      // Publish the updated list
+      await publishEvent({
+        kind: 14550,
+        tags,
+        content: "",
+      });
+      
+      // Invalidate queries
+      queryClient.invalidateQueries({ queryKey: ["approved-members-list", communityId] });
+      
+      return { 
+        success: true, 
+        message: "User removed from approved members list" 
+      };
+    } catch (error) {
+      console.error("Error removing user from approved list:", error);
+      return { 
+        success: false, 
+        message: "Failed to remove user from approved members list" 
+      };
+    }
+  };
+
+  return {
+    removeFromApprovedList,
+    isPending
+  };
+}

--- a/src/hooks/useUpdateApprovedMembers.ts
+++ b/src/hooks/useUpdateApprovedMembers.ts
@@ -62,6 +62,7 @@ export function useUpdateApprovedMembers() {
       
       // Check if the user is in the approved list
       if (!currentApprovedMembers.includes(pubkey)) {
+        // Return success but with a message indicating the user wasn't found
         return { 
           success: true, 
           message: "User is not in the approved members list" 

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -16,10 +16,11 @@ import { useAuthor } from "@/hooks/useAuthor";
 import { CreatePostForm } from "@/components/groups/CreatePostForm";
 import { PostList } from "@/components/groups/PostList";
 import { PendingPostsList } from "@/components/groups/PendingPostsList";
+import { ReportsList } from "@/components/groups/ReportsList";
 import { JoinRequestButton } from "@/components/groups/JoinRequestButton";
 import { MemberManagement } from "@/components/groups/MemberManagement";
 import { ApprovedMembersList } from "@/components/groups/ApprovedMembersList";
-import { Users, Settings, Info, MessageSquare, CheckCircle, UserPlus, Clock, Pin, PinOff } from "lucide-react";
+import { Users, Settings, Info, MessageSquare, CheckCircle, UserPlus, Clock, Pin, PinOff, Flag } from "lucide-react";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 import Header from "@/components/ui/Header";
 import { usePinnedGroups } from "@/hooks/usePinnedGroups";
@@ -259,6 +260,12 @@ export default function GroupDetail() {
             <Users className="h-4 w-4 mr-2" />
             Members
           </TabsTrigger>
+          {isModerator && (
+            <TabsTrigger value="reports">
+              <Flag className="h-4 w-4 mr-2" />
+              Reports
+            </TabsTrigger>
+          )}
           <TabsTrigger value="about">
             <Info className="h-4 w-4 mr-2" />
             About
@@ -327,6 +334,12 @@ export default function GroupDetail() {
           </div>
         </TabsContent>
 
+        {isModerator && (
+          <TabsContent value="reports" className="space-y-4">
+            <ReportsList communityId={groupId || ''} />
+          </TabsContent>
+        )}
+        
         <TabsContent value="about">
           <Card>
             <CardHeader>


### PR DESCRIPTION
fixes #59 

Uses Kind 1984 for reports, and new invented kind 4554 for Mods response to reports

**To Do:**
- [x] Submitting a report
- [x] Viewing Reports
- [x] Removing a post in response to a report
- [x] How to mark reports as closed
- [x] Kind 1985 events being submitted on every mod action? 
- [x] Remove a user from group in response to report
- [x] Ban user from group in response to report


![Screenshot from 2025-05-22 10-02-44](https://github.com/user-attachments/assets/249d6435-d24d-4a52-be0d-13d3eb7193a3)

![Screenshot from 2025-05-22 11-27-43](https://github.com/user-attachments/assets/cb019524-2b2c-49de-b55e-54dfc5226b49)

![Screenshot from 2025-05-22 11-28-03](https://github.com/user-attachments/assets/a535ec2c-0e96-4b1a-817c-7ba29609b3ef)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Report" button for posts, allowing users to report inappropriate content (visible only if logged in and not the post author).
  - Added a report dialog where users can specify the reason for reporting a post.
  - Added a "Reports" tab in group pages for moderators to review and manage reported content.
  - Moderators can take actions on reports, including removing content, removing users, or banning users.
  - Enhanced moderation tools with detailed reports list, content previews, and action confirmation dialogs.
  - Improved user management with approved members update and flexible banning capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->