### PR TITLE
check if nutzap receiver has the same mints

### DIFF
--- a/src/components/cashu/NutzapCard.tsx
+++ b/src/components/cashu/NutzapCard.tsx
@@ -277,6 +277,14 @@ export function NutzapCard() {
       // Generate token (mint) with the specified amount and get proofs for the nutzap
       const amountValue = parseInt(amount);
 
+      // Verify the mint is in the recipient's trusted list
+      const recipientMints = recipientInfo.mints.map((mint) => mint.url);
+      if (!recipientMints.includes(cashuStore.activeMintUrl)) {
+        throw new Error(
+          `Recipient does not accept tokens from mint: ${cashuStore.activeMintUrl}`
+        );
+      }
+
       // Send token using p2pk pubkey from recipient info
       const proofs = (await sendToken(
         cashuStore.activeMintUrl,

--- a/src/pages/CashuWallet.tsx
+++ b/src/pages/CashuWallet.tsx
@@ -20,7 +20,7 @@ export function CashuWallet() {
         <CashuWalletCard />
         <NutzapCard />
         <CashuWalletLightningCard />
-        <CashuTokenCard />
+        {/* <CashuTokenCard /> */}
         <CashuHistoryCard />
       </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a validation step to prevent sending tokens to recipients who do not accept tokens from the selected mint.

- **Refactor**
  - Disabled the display of the token card in the wallet view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->