### PR TITLE
Cashu: nutzaps -> zaps and Cash

### DIFF
--- a/src/components/groups/NutzapButton.tsx
+++ b/src/components/groups/NutzapButton.tsx
@@ -25,7 +25,11 @@ interface NutzapButtonProps {
   relayHint?: string;
 }
 
-export function NutzapButton({ postId, authorPubkey, relayHint }: NutzapButtonProps) {
+export function NutzapButton({
+  postId,
+  authorPubkey,
+  relayHint,
+}: NutzapButtonProps) {
   const { user } = useCurrentUser();
   const { wallet } = useCashuWallet();
   const cashuStore = useCashuStore();
@@ -43,17 +47,19 @@ export function NutzapButton({ postId, authorPubkey, relayHint }: NutzapButtonPr
       toast.error("You must be logged in to send nutzaps");
       return;
     }
-    
+
     if (!wallet) {
       toast.error("You need to set up a Cashu wallet first");
       return;
     }
-    
+
     if (!cashuStore.activeMintUrl) {
-      toast.error("No active mint selected. Please select a mint in your wallet settings.");
+      toast.error(
+        "No active mint selected. Please select a mint in your wallet settings."
+      );
       return;
     }
-    
+
     setIsDialogOpen(true);
   };
 
@@ -90,7 +96,7 @@ export function NutzapButton({ postId, authorPubkey, relayHint }: NutzapButtonPr
         proofs,
         mintUrl: cashuStore.activeMintUrl,
         eventId: postId,
-        relayHint
+        relayHint,
       });
 
       toast.success(`Successfully sent ${amountValue} sats`);
@@ -114,15 +120,15 @@ export function NutzapButton({ postId, authorPubkey, relayHint }: NutzapButtonPr
         onClick={handleOpenDialog}
       >
         <Zap className="h-3.5 w-3.5 mr-1" />
-        <span className="text-xs">Nutzap</span>
+        <span className="text-xs">Zap</span>
       </Button>
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
-            <DialogTitle>Send Nutzap</DialogTitle>
+            <DialogTitle>Send Cash</DialogTitle>
             <DialogDescription>
-              Send a Cashu token to the author of this post.
+              Send Cash to the author of this post.
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
@@ -153,12 +159,12 @@ export function NutzapButton({ postId, authorPubkey, relayHint }: NutzapButtonPr
             </div>
           </div>
           <DialogFooter>
-            <Button 
-              type="submit" 
+            <Button
+              type="submit"
               onClick={handleSendNutzap}
               disabled={isProcessing || isSending || isFetching || !amount}
             >
-              {isProcessing ? "Sending..." : "Send Nutzap"}
+              {isProcessing ? "Sending..." : "Send Cash"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/groups/NutzapList.tsx
+++ b/src/components/groups/NutzapList.tsx
@@ -127,7 +127,7 @@ export function NutzapList({ postId }: NutzapListProps) {
       <div className="flex items-center gap-1 mb-2">
         <Zap className="h-3.5 w-3.5 text-amber-500" />
         <span className="text-xs font-medium">
-          {totalAmount} sats from {nutzaps.length} cash zap
+          {totalAmount} sats from {nutzaps.length} zap
           {nutzaps.length !== 1 ? "s" : ""}
         </span>
       </div>

--- a/src/hooks/useSendNutzap.ts
+++ b/src/hooks/useSendNutzap.ts
@@ -27,7 +27,7 @@ export function useFetchNutzapInfo() {
       ], { signal: AbortSignal.timeout(5000) });
 
       if (events.length === 0) {
-        throw new Error('Recipient has no nutzap informational event');
+        throw new Error('Recipient has no Cash wallet');
       }
 
       const event = events[0];
@@ -138,10 +138,10 @@ export function useSendNutzap() {
       if (eventId) {
         queryClient.invalidateQueries({ queryKey: ['nutzaps', eventId] });
       }
-      
+
       // Also invalidate recipient's received nutzaps
-      queryClient.invalidateQueries({ 
-        queryKey: ['nutzap', 'received', recipientInfo.event.pubkey] 
+      queryClient.invalidateQueries({
+        queryKey: ['nutzap', 'received', recipientInfo.event.pubkey]
       });
 
       // Return the event


### PR DESCRIPTION
<img width="466" alt="image" src="https://github.com/user-attachments/assets/ec47b529-4a7c-4f32-9be9-4004e18d44e1" />

should we rename the zap button to "Cash"?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all user-facing text to replace "Nutzap" with "Zap" or "Cash" across buttons, labels, and descriptions for a more consistent experience.
  - Improved formatting and readability of displayed messages and lists.
- **Style**
  - Enhanced code formatting and consistency, resulting in cleaner layouts and improved clarity in UI elements.
- **Bug Fixes**
  - Clarified error messages to better inform users when a recipient does not have a Cash wallet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->