### PR TITLE
Cashu: change mint to zap receivers

### DIFF
--- a/src/hooks/useSendNutzap.ts
+++ b/src/hooks/useSendNutzap.ts
@@ -2,8 +2,47 @@ import { useNostr } from '@/hooks/useNostr';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CASHU_EVENT_KINDS } from '@/lib/cashu';
+import { NostrEvent } from 'nostr-tools';
 import { Proof } from '@cashu/cashu-ts';
 import { useNutzapStore, NutzapInformationalEvent } from '@/stores/nutzapStore';
+import { useCashuStore } from '@/stores/cashuStore';
+
+/**
+ * Hook to verify mint compatibility between sender and recipient
+ * Checks if recipient accepts tokens from sender's active mint
+ * If not, tries to find a compatible mint from sender's mints list
+ */
+export function useVerifyMintCompatibility() {
+  const cashuStore = useCashuStore();
+
+  const verifyMintCompatibility = (recipientInfo: NutzapInformationalEvent): string => {
+    const activeMintUrl = cashuStore.activeMintUrl || '';
+    const recipientMints = recipientInfo.mints.map(mint => mint.url);
+
+    // Check if recipient accepts the active mint
+    if (activeMintUrl && recipientMints.includes(activeMintUrl)) {
+      return activeMintUrl;
+    }
+
+    // If not, try to find a compatible mint
+    const compatibleMint = recipientMints.find(mintUrl =>
+      cashuStore.mints.map(m => m.url).includes(mintUrl)
+    );
+
+    if (compatibleMint) {
+      // Update the active mint to the compatible one
+      cashuStore.setActiveMintUrl(compatibleMint);
+      return compatibleMint;
+    }
+
+    // No compatible mint found
+    throw new Error(
+      `Recipient does not accept tokens from mint: ${activeMintUrl}`
+    );
+  };
+
+  return { verifyMintCompatibility };
+}
 
 /**
  * Hook to fetch a recipient's nutzap information
@@ -79,6 +118,7 @@ export function useFetchNutzapInfo() {
 export function useSendNutzap() {
   const { nostr } = useNostr();
   const { user } = useCurrentUser();
+  const { verifyMintCompatibility } = useVerifyMintCompatibility();
   const queryClient = useQueryClient();
 
   // Mutation to create and send a nutzap event
@@ -100,10 +140,13 @@ export function useSendNutzap() {
     }) => {
       if (!user) throw new Error('User not logged in');
 
-      // Verify the mint is in the recipient's trusted list
-      const recipientMints = recipientInfo.mints.map(mint => mint.url);
-      if (!recipientMints.includes(mintUrl)) {
-        throw new Error(`Recipient does not accept tokens from mint: ${mintUrl}`);
+      // Verify mint compatibility and get the compatible mint URL
+      const compatibleMintUrl = verifyMintCompatibility(recipientInfo);
+
+      // If mintUrl is different from compatibleMintUrl, we should use the compatible one
+      // but this requires generating new proofs with the compatible mint
+      if (mintUrl !== compatibleMintUrl) {
+        mintUrl = compatibleMintUrl;
       }
 
       // Create tags for the nutzap event
@@ -138,10 +181,10 @@ export function useSendNutzap() {
       if (eventId) {
         queryClient.invalidateQueries({ queryKey: ['nutzaps', eventId] });
       }
-      
+
       // Also invalidate recipient's received nutzaps
-      queryClient.invalidateQueries({ 
-        queryKey: ['nutzap', 'received', recipientInfo.event.pubkey] 
+      queryClient.invalidateQueries({
+        queryKey: ['nutzap', 'received', recipientInfo.event.pubkey]
       });
 
       // Return the event

--- a/src/stores/cashuStore.ts
+++ b/src/stores/cashuStore.ts
@@ -40,6 +40,7 @@ interface CashuStore {
   getMintQuote: (mintUrl: string, quoteId: string) => MintQuoteResponse;
   getMeltQuote: (mintUrl: string, quoteId: string) => MeltQuoteResponse;
   setActiveMintUrl: (url: string) => void;
+  getActiveMintUrl: () => string | undefined;
 }
 
 // Usage:
@@ -172,6 +173,10 @@ export const useCashuStore = create<CashuStore>()(
 
       setActiveMintUrl(url: string) {
         set({ activeMintUrl: url });
+      },
+
+      getActiveMintUrl() {
+        return get().activeMintUrl;
       },
     }),
     { name: 'cashu' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved mint compatibility checks when sending tokens or nutzaps, ensuring a compatible mint is automatically selected for the recipient.
- **Bug Fixes**
  - Prevented errors when the recipient does not support the sender’s active mint by dynamically verifying and switching to a compatible mint if needed.
- **Enhancements**
  - Streamlined token and nutzap sending processes for smoother user experience with recipients using different mints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->