### PR TITLE
Remove unnecessary step

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,6 @@ Chorus implements several Nostr Improvement Proposals (NIPs) to provide a rich f
 # Clone the repository
 git clone https://github.com/andotherstuff/chorus.git
 
-# Install dependencies
-npm install
-
 # Start development server
 npm run dev
 


### PR DESCRIPTION
The `npm run dev` already contains `npm i`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Local Development section in the README to simplify setup instructions by removing the explicit dependency installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->