### PR TITLE
refactor: update UI to use eCash terminology and consistent button styling

### DIFF
--- a/src/components/cashu/CashuHistoryCard.tsx
+++ b/src/components/cashu/CashuHistoryCard.tsx
@@ -193,7 +193,7 @@ export function CashuHistoryCard() {
                       entry.redeemedTokens &&
                       entry.redeemedTokens.length > 0 && (
                         <p className="text-xs text-muted-foreground mt-1">
-                          Redeemed from nutzap
+                          Redeemed from eCash
                         </p>
                       )}
                     {isPending(entry) && (

--- a/src/components/cashu/NutzapCard.tsx
+++ b/src/components/cashu/NutzapCard.tsx
@@ -20,6 +20,7 @@ import {
   ChevronDown,
   ChevronUp,
   Copy,
+  DollarSign,
   Zap,
 } from "lucide-react";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -189,7 +190,7 @@ export function NutzapCard() {
 
               // Show success notification for redeemed nutzap
               setSuccess(
-                `New Zap received and redeemed! ${proofs.reduce(
+                `New eCash received and redeemed! ${proofs.reduce(
                   (sum, p) => sum + p.amount,
                   0
                 )} sats`
@@ -198,7 +199,7 @@ export function NutzapCard() {
               console.error("Failed to auto-redeem nutzap:", error);
               // Just show the notification without auto-redemption
               setSuccess(
-                `New Zap received! ${proofs.reduce(
+                `New eCash received! ${proofs.reduce(
                   (sum, p) => sum + p.amount,
                   0
                 )} sats`
@@ -350,7 +351,7 @@ export function NutzapCard() {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Cash Zaps</CardTitle>
+          <CardTitle>eCash</CardTitle>
           <CardDescription>Create a wallet first</CardDescription>
         </CardHeader>
       </Card>
@@ -361,7 +362,7 @@ export function NutzapCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
         <div>
-          <CardTitle>Cash Zaps</CardTitle>
+          <CardTitle>eCash</CardTitle>
           <CardDescription>Send and receive Cash via Nostr</CardDescription>
         </div>
         <Button
@@ -434,8 +435,8 @@ export function NutzapCard() {
                   isSending
                 }
               >
-                {isSending ? "Sending..." : "Send Zap"}
-                <Zap className="h-4 w-4 ml-2" />
+                {isSending ? "Sending..." : "Send eCash"}
+                <DollarSign className="h-4 w-4 ml-2" />
               </Button>
             </TabsContent>
 
@@ -463,7 +464,7 @@ export function NutzapCard() {
               )}
 
               {isLoadingNutzaps && receivedNutzaps.length === 0 ? (
-                <div className="text-center py-4">Loading incoming zaps...</div>
+                <div className="text-center py-4">Loading incoming eCash...</div>
               ) : receivedNutzaps.length > 0 ? (
                 <div className="space-y-4">
                   {receivedNutzaps.map((nutzap) => (
@@ -519,7 +520,7 @@ export function NutzapCard() {
                 </div>
               ) : (
                 <div className="text-center py-4 text-sm text-muted-foreground">
-                  No incoming zaps received yet
+                  No incoming eCash received yet
                 </div>
               )}
 

--- a/src/components/groups/GroupNutzapButton.tsx
+++ b/src/components/groups/GroupNutzapButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Zap } from "lucide-react";
+import { Zap, DollarSign } from "lucide-react";
 import { useSendNutzap, useFetchNutzapInfo } from "@/hooks/useSendNutzap";
 import { useCashuWallet } from "@/hooks/useCashuWallet";
 import { useCashuStore } from "@/stores/cashuStore";
@@ -48,7 +48,7 @@ export function GroupNutzapButton({
 
   const handleOpenDialog = () => {
     if (!user) {
-      toast.error("You must be logged in to send nutzaps");
+      toast.error("You must be logged in to send eCash");
       return;
     }
     
@@ -122,8 +122,8 @@ export function GroupNutzapButton({
         className={`flex items-center ${className}`}
         onClick={handleOpenDialog}
       >
-        <Zap className="h-4 w-4 mr-2" />
-        <span>Nutzap Group</span>
+        <DollarSign className="h-4 w-4 mr-2" />
+        <span>eCash Group</span>
       </Button>
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
@@ -131,7 +131,7 @@ export function GroupNutzapButton({
           <DialogHeader>
             <DialogTitle>Support this Group</DialogTitle>
             <DialogDescription>
-              Send a Cashu token to the group owner to show your support.
+              Send eCash to the group owner to show your support.
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
@@ -167,7 +167,7 @@ export function GroupNutzapButton({
               onClick={handleSendNutzap}
               disabled={isProcessing || isSending || isFetching || !amount}
             >
-              {isProcessing ? "Sending..." : "Send Nutzap"}
+              {isProcessing ? "Sending..." : "Send eCash"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/groups/GroupNutzapList.tsx
+++ b/src/components/groups/GroupNutzapList.tsx
@@ -4,7 +4,7 @@ import { formatBalance } from "@/lib/cashu";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Zap } from "lucide-react";
+import { Zap, DollarSign } from "lucide-react";
 import { Link } from "react-router-dom";
 
 interface GroupNutzapListProps {
@@ -45,7 +45,7 @@ export function GroupNutzapList({ groupId }: GroupNutzapListProps) {
     return (
       <Card>
         <CardContent className="pt-6 text-center text-muted-foreground">
-          No nutzaps for this group yet.
+          No eCash for this group yet.
         </CardContent>
       </Card>
     );
@@ -98,7 +98,7 @@ function NutzapItem({ event }: { event: any }) {
             </div>
           </Link>
           <div className="flex items-center text-amber-500">
-            <Zap className="h-4 w-4 mr-1" />
+            <DollarSign className="h-4 w-4 mr-1" />
             <span className="font-medium">{formatBalance(totalAmount)}</span>
           </div>
         </div>

--- a/src/components/groups/GroupNutzapTotal.tsx
+++ b/src/components/groups/GroupNutzapTotal.tsx
@@ -1,6 +1,6 @@
 import { useGroupNutzapTotal } from "@/hooks/useGroupNutzaps";
 import { formatBalance } from "@/lib/cashu";
-import { Zap } from "lucide-react";
+import { Zap, DollarSign } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface GroupNutzapTotalProps {
@@ -21,7 +21,7 @@ export function GroupNutzapTotal({ groupId, className = "" }: GroupNutzapTotalPr
 
   return (
     <div className={`flex items-center text-amber-500 ${className}`}>
-      <Zap className="h-4 w-4 mr-1" />
+      <DollarSign className="h-4 w-4 mr-1" />
       <span>{formatBalance(total)}</span>
     </div>
   );

--- a/src/components/groups/JoinRequestButton.tsx
+++ b/src/components/groups/JoinRequestButton.tsx
@@ -8,15 +8,17 @@ import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { toast } from "sonner";
 import { UserPlus, CheckCircle, Clock, XCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface JoinRequestButtonProps {
   communityId: string;
   isModerator?: boolean;
   initialOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  className?: string;
 }
 
-export function JoinRequestButton({ communityId, isModerator = false, initialOpen = false, onOpenChange }: JoinRequestButtonProps) {
+export function JoinRequestButton({ communityId, isModerator = false, initialOpen = false, onOpenChange, className }: JoinRequestButtonProps) {
   const [open, setOpen] = useState(initialOpen);
   const [joinReason, setJoinReason] = useState("");
   const { user } = useCurrentUser();
@@ -117,7 +119,7 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
 
   if (!user) {
     return (
-      <Button variant="outline" disabled className="w-full">
+      <Button variant="outline" disabled className={className}>
         <UserPlus className="h-4 w-4 mr-2" />
         Log in to join
       </Button>
@@ -126,7 +128,7 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
 
   if (isCheckingRequest || isCheckingApproval || isCheckingDeclined) {
     return (
-      <Button variant="outline" disabled className="w-full">
+      <Button variant="outline" disabled className={className}>
         <Clock className="h-4 w-4 mr-2 animate-spin" />
         Checking status...
       </Button>
@@ -136,7 +138,7 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
   // If user is in both approved and declined lists, treat them as approved
   if (isApprovedMember) {
     return (
-      <Button variant="outline" disabled className="text-green-600 border-green-600 w-full">
+      <Button variant="outline" disabled className={cn("text-green-600 border-green-600", className)}>
         <CheckCircle className="h-4 w-4 mr-2" />
         Member
       </Button>
@@ -145,7 +147,7 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
 
   if (existingRequest) {
     return (
-      <Button variant="outline" disabled className="w-full">
+      <Button variant="outline" disabled className={className}>
         <Clock className="h-4 w-4 mr-2" />
         Request pending
       </Button>
@@ -154,7 +156,7 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
   
   if (isDeclinedUser) {
     return (
-      <Button variant="outline" disabled className="text-red-600 border-red-600">
+      <Button variant="outline" disabled className={cn("text-red-600 border-red-600", className)}>
         <XCircle className="h-4 w-4 mr-2" />
         Request declined
       </Button>
@@ -164,7 +166,7 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant="outline" className="w-full">
+        <Button variant="outline" className={className}>
           <UserPlus className="h-4 w-4 mr-2" />
           Request to join
         </Button>

--- a/src/components/groups/NutzapButton.tsx
+++ b/src/components/groups/NutzapButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Zap } from "lucide-react";
+import { Zap, DollarSign } from "lucide-react";
 import {
   useSendNutzap,
   useFetchNutzapInfo,
@@ -94,7 +94,7 @@ export function NutzapButton({ postId, authorPubkey, relayHint, showText = true 
 
   const handleOpenDialog = () => {
     if (!user) {
-      toast.error("You must be logged in to send nutzaps");
+      toast.error("You must be logged in to send eCash");
       return;
     }
 
@@ -172,7 +172,7 @@ export function NutzapButton({ postId, authorPubkey, relayHint, showText = true 
         className="text-muted-foreground hover:text-foreground flex items-center h-7 px-1.5"
         onClick={handleOpenDialog}
       >
-        <Zap className={`h-3.5 w-3.5 ${nutzapTotal && nutzapTotal > 0 ? 'text-orange-500' : ''}`} />
+        <DollarSign className={`h-3.5 w-3.5 ${nutzapTotal && nutzapTotal > 0 ? 'text-orange-500' : ''}`} />
         {nutzapTotal && nutzapTotal > 0 ? <span className="text-xs ml-0.5">{nutzapTotal}</span> : null}
       </Button>
 

--- a/src/components/groups/NutzapList.tsx
+++ b/src/components/groups/NutzapList.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Zap } from "lucide-react";
+import { Zap, DollarSign } from "lucide-react";
 import { CASHU_EVENT_KINDS } from "@/lib/cashu";
 import { Proof } from "@cashu/cashu-ts";
 
@@ -118,10 +118,9 @@ export function NutzapList({ postId }: NutzapListProps) {
   return (
     <div className="mt-2 border-t pt-2">
       <div className="flex items-center gap-1 mb-2">
-        <Zap className="h-3.5 w-3.5 text-amber-500" />
+        <DollarSign className="h-3.5 w-3.5 text-amber-500" />
         <span className="text-xs font-medium">
-          {totalAmount} sats from {nutzaps.length} zap
-          {nutzaps.length !== 1 ? "s" : ""}
+          {totalAmount} sats in {nutzaps.length} eCash
         </span>
       </div>
 
@@ -138,7 +137,7 @@ export function NutzapList({ postId }: NutzapListProps) {
           className="text-xs mt-1 h-6 px-2"
           onClick={() => setShowAll(!showAll)}
         >
-          {showAll ? "Show less" : `Show ${nutzaps.length - 3} more Cash zaps`}
+          {showAll ? "Show less" : `Show ${nutzaps.length - 3} more eCash`}
         </Button>
       )}
     </div>

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -20,7 +20,7 @@ import { ApprovedMembersList } from "@/components/groups/ApprovedMembersList";
 import { GroupNutzapButton } from "@/components/groups/GroupNutzapButton";
 import { GroupNutzapTotal } from "@/components/groups/GroupNutzapTotal";
 import { GroupNutzapList } from "@/components/groups/GroupNutzapList";
-import { Users, Settings, Info, MessageSquare, CheckCircle, UserPlus, Clock, Pin, PinOff, Flag, Zap } from "lucide-react";
+import { Users, Settings, Info, MessageSquare, CheckCircle, UserPlus, Clock, Pin, PinOff, Flag, Zap, DollarSign } from "lucide-react";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 import Header from "@/components/ui/Header";
 import { usePinnedGroups } from "@/hooks/usePinnedGroups";
@@ -192,18 +192,19 @@ export default function GroupDetail() {
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-3">
             <GroupNutzapTotal groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`} />
+          </div>
+          <div className="flex items-center gap-4">
             {user && community && (
               <GroupNutzapButton
                 groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`}
                 ownerPubkey={community.pubkey}
                 variant="outline"
-                size="sm"
               />
             )}
+            {!isModerator && (
+              <JoinRequestButton communityId={groupId || ''} isModerator={isModerator} />
+            )}
           </div>
-          {!isModerator && (
-            <JoinRequestButton communityId={groupId || ''} isModerator={isModerator} />
-          )}
         </div>
       </div>
 
@@ -220,9 +221,9 @@ export default function GroupDetail() {
               Members
             </TabsTrigger>
 
-            <TabsTrigger value="nutzaps">
-              <Zap className="h-4 w-4 mr-2" />
-              Nutzaps
+            <TabsTrigger value="ecash">
+              <DollarSign className="h-4 w-4 mr-2" />
+              eCash
             </TabsTrigger>
           </TabsList>
         </div>
@@ -260,9 +261,9 @@ export default function GroupDetail() {
           </div>
         </TabsContent>
 
-        <TabsContent value="nutzaps" className="space-y-4">
+        <TabsContent value="ecash" className="space-y-4">
           <div className="flex justify-between items-center mb-4">
-            <h2 className="text-xl font-semibold">Group Nutzaps</h2>
+            <h2 className="text-xl font-semibold">Group eCash</h2>
             {user && community && (
               <GroupNutzapButton
                 groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`}


### PR DESCRIPTION
This PR updates the UI to consistently use 'eCash' terminology throughout the application and improves button styling consistency:

- Replace all instances of 'nutzap' with 'eCash'
- Replace Zap icon with DollarSign icon for eCash-related elements 
- Make eCash group and join request buttons consistent in height and spacing
- Add className prop to JoinRequestButton for flexible styling
- Fix button layout in group header with proper spacing

Visual Changes:
- Both buttons in the group header now have consistent height
- 1rem (16px) spacing between buttons
- Consistent use of DollarSign icon instead of Zap
- All terminology updated to use 'eCash' instead of 'nutzap'

Screenshots:
Before: Buttons had different heights and inconsistent spacing
After: Buttons are now aligned with consistent spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for customizing button styles in group join requests.

- **Style**
	- Updated all user-facing references from "Zap" or "Nutzap" to "eCash" across group and transaction interfaces.
	- Replaced Zap icons with DollarSign icons in relevant buttons, lists, and summaries.
	- Adjusted group detail page layout and tab labels to reflect the new "eCash" terminology.

- **Bug Fixes**
	- Updated transaction history text to display "Redeemed from eCash" instead of "Redeemed from nutzap".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->