### PR TITLE
feat: add real-time USD display for sats with flash animations

### DIFF
--- a/src/hooks/useBitcoinPrice.ts
+++ b/src/hooks/useBitcoinPrice.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+
+interface BitcoinPrice {
+  USD: number;
+}
+
+export function useBitcoinPrice() {
+  return useQuery({
+    queryKey: ["bitcoin-price"],
+    queryFn: async () => {
+      const response = await fetch("https://api.coinbase.com/v2/exchange-rates?currency=BTC");
+      
+      if (!response.ok) {
+        throw new Error("Failed to fetch Bitcoin price");
+      }
+      
+      const data = await response.json();
+      const usdPrice = parseFloat(data.data.rates.USD);
+      
+      return { USD: usdPrice };
+    },
+    refetchInterval: 10000, // Refetch every 10 seconds
+    staleTime: 5000, // Consider data fresh for 5 seconds
+  });
+}
+
+export function satsToUSD(sats: number, bitcoinPrice: number): number {
+  // Convert sats to BTC (1 BTC = 100,000,000 sats)
+  const btc = sats / 100_000_000;
+  // Convert BTC to USD
+  return btc * bitcoinPrice;
+}
+
+export function formatUSD(amount: number): string {
+  const formatted = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+  
+  return `${formatted} USD`;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -99,3 +99,19 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes flash-update {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.flash-update {
+  animation: flash-update 0.3s ease-in-out;
+}


### PR DESCRIPTION
## Changes

- Add bitcoin price hook that fetches real-time price from Coinbase API
- Update refresh interval to 10 seconds (previously 60 seconds)
- Display USD by default with 'USD' suffix (e.g., $1.23 USD)
- Add click-to-toggle functionality between USD and sats
- Implement flash animation when values update in real-time
- Add CSS keyframe animation for smooth visual feedback

## Components Updated

- **GroupNutzapTotal**: Shows total sats/USD with toggle on click
- **GroupNutzapList**: Lists individual nutzaps with toggle button
- **CashuWalletCard**: Shows mint balances with toggle option

## Key Features

- Real-time bitcoin price updates every 10 seconds
- Flash animation triggers only on USD value changes
- Graceful fallback to sats display if price data unavailable
- Consistent amber color for all monetary values
- Tabular-nums CSS for aligned number display
- Reduces cognitive load by showing familiar USD values

## Testing

- Verified flash animations trigger on price updates
- Tested toggle functionality across all components
- Confirmed fallback behavior when API unavailable
- Checked responsive design on mobile
- Validated proper USD formatting with suffix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to toggle balance and transaction displays between sats and USD across wallet and group views.
	- Live Bitcoin price is fetched and used for real-time USD conversion.
- **Enhancements**
	- Visual flash animation highlights updates to USD values for improved feedback.
- **Style**
	- Introduced new animation for value updates to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->