### PR TITLE
Add mod notification icons to cards 

### DIFF
--- a/src/components/groups/GroupCard.tsx
+++ b/src/components/groups/GroupCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Pin, PinOff, MessageSquare, Activity, MoreVertical } from "lucide-react";
+import { Pin, PinOff, MessageSquare, Activity, MoreVertical, UserPlus, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { RoleBadge } from "@/components/groups/RoleBadge";
@@ -133,15 +133,17 @@ export function GroupCard({
                   {openReportsCount > 0 && (
                     <Badge 
                       variant="destructive" 
-                      className="h-5 w-5 p-0 flex items-center justify-center text-xs"
+                      className="h-6 w-auto px-1.5 py-0 flex items-center justify-center text-xs gap-1"
                     >
+                      <AlertTriangle className="h-2.5 w-2.5" />
                       {openReportsCount > 99 ? '99+' : openReportsCount}
                     </Badge>
                   )}
                   {pendingRequestsCount > 0 && (
                     <Badge 
-                      className="h-5 w-5 p-0 flex items-center justify-center text-xs bg-blue-500 hover:bg-blue-600"
+                      className="h-6 w-auto px-1.5 py-0 flex items-center justify-center text-xs gap-1 bg-blue-500 hover:bg-blue-600"
                     >
+                      <UserPlus className="h-2.5 w-2.5" />
                       {pendingRequestsCount > 99 ? '99+' : pendingRequestsCount}
                     </Badge>
                   )}


### PR DESCRIPTION
![Screenshot from 2025-05-22 23-39-57](https://github.com/user-attachments/assets/f1e0bbfb-1d0b-4e93-b0fe-c01c362faa34)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added notification badges to group cards for owners and moderators, showing counts of open reports and pending join requests.
  - Badges include icons, tooltips with detailed counts, and special styling for easy identification.
  - Badges are only visible to users with owner or moderator roles when there are pending items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->