### PR TITLE
Add QR Code Sharing Feature to Profile and Group Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "lucide-react": "^0.462.0",
         "marked": "^15.0.12",
         "next-themes": "^0.3.0",
+        "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -5514,6 +5515,15 @@
       "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
       "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
       "license": "MIT"
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lucide-react": "^0.462.0",
     "marked": "^15.0.12",
     "next-themes": "^0.3.0",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/src/components/QRCodeModal.tsx
+++ b/src/components/QRCodeModal.tsx
@@ -1,0 +1,97 @@
+import { QRCodeSVG } from 'qrcode.react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Copy, Download } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface QRCodeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  profileUrl: string;
+  displayName: string;
+}
+
+export function QRCodeModal({ isOpen, onClose, profileUrl, displayName }: QRCodeModalProps) {
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(profileUrl);
+    toast.success('Profile link copied to clipboard');
+  };
+
+  const handleDownloadQR = () => {
+    // Get the QR code SVG element
+    const svg = document.getElementById('profile-qr-code');
+    if (!svg) return;
+
+    // Convert SVG to canvas
+    const svgData = new XMLSerializer().serializeToString(svg);
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+
+    img.onload = () => {
+      canvas.width = img.width;
+      canvas.height = img.height;
+      ctx?.drawImage(img, 0, 0);
+      
+      // Convert canvas to download link
+      const pngUrl = canvas.toDataURL('image/png');
+      const downloadLink = document.createElement('a');
+      downloadLink.download = `${displayName}-profile-qr.png`;
+      downloadLink.href = pngUrl;
+      downloadLink.click();
+    };
+
+    img.src = 'data:image/svg+xml;base64,' + btoa(svgData);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share Profile</DialogTitle>
+          <DialogDescription>
+            Scan this QR code to view {displayName}'s profile
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col items-center space-y-4 py-4">
+          <div className="bg-white p-4 rounded-lg">
+            <QRCodeSVG
+              id="profile-qr-code"
+              value={profileUrl}
+              size={200}
+              level="M"
+              includeMargin={false}
+            />
+          </div>
+          <div className="flex flex-col sm:flex-row gap-2 w-full">
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={handleCopyLink}
+            >
+              <Copy className="h-4 w-4 mr-2" />
+              Copy Link
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={handleDownloadQR}
+            >
+              <Download className="h-4 w-4 mr-2" />
+              Download QR
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground text-center break-all">
+            {profileUrl}
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -21,9 +21,10 @@ import { SimpleMembersList } from "@/components/groups/SimpleMembersList";
 import { GroupNutzapButton } from "@/components/groups/GroupNutzapButton";
 import { GroupNutzapTotal } from "@/components/groups/GroupNutzapTotal";
 import { GroupNutzapList } from "@/components/groups/GroupNutzapList";
-import { Users, Settings, MessageSquare, CheckCircle, DollarSign } from "lucide-react";
+import { Users, Settings, MessageSquare, CheckCircle, DollarSign, QrCode } from "lucide-react";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 import Header from "@/components/ui/Header";
+import { QRCodeModal } from "@/components/QRCodeModal";
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -36,6 +37,7 @@ export default function GroupDetail() {
   const [showOnlyApproved, setShowOnlyApproved] = useState(true);
   const [currentPostCount, setCurrentPostCount] = useState(0);
   const [activeTab, setActiveTab] = useState("posts");
+  const [showQRCode, setShowQRCode] = useState(false);
 
   
   const searchParams = new URLSearchParams(location.search);
@@ -191,12 +193,30 @@ export default function GroupDetail() {
           <div className="flex flex-col justify-between min-w-[140px] h-36">
             {!isModerator ? (
               <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5 mb-2"
+                  onClick={() => setShowQRCode(true)}
+                >
+                  <QrCode className="h-4 w-4" />
+                  QR Code
+                </Button>
                 <JoinRequestButton communityId={groupId || ''} isModerator={isModerator} />
                 <div className="flex-1" />
                 <GroupNutzapTotal groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`} />
               </>
             ) : (
               <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5 mb-2"
+                  onClick={() => setShowQRCode(true)}
+                >
+                  <QrCode className="h-4 w-4" />
+                  QR Code
+                </Button>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -333,6 +353,14 @@ export default function GroupDetail() {
           </div>
         </TabsContent>
       </Tabs>
+
+      {/* QR Code Modal */}
+      <QRCodeModal
+        isOpen={showQRCode}
+        onClose={() => setShowQRCode(false)}
+        profileUrl={`${window.location.origin}/group/${encodeURIComponent(groupId || '')}`}
+        displayName={name}
+      />
     </div>
   );
 }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -30,7 +30,8 @@ import {
   Share2,
   LinkIcon,
   MoreVertical,
-  Flag
+  Flag,
+  QrCode
 } from "lucide-react";
 import { toast } from "sonner";
 import type { NostrEvent } from "@nostrify/nostrify";
@@ -53,6 +54,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { QRCodeModal } from "@/components/QRCodeModal";
 
 // Helper function to extract group information from a post
 function extractGroupInfo(post: NostrEvent): { groupId: string; groupName: string } | null {
@@ -520,6 +522,7 @@ export default function Profile() {
   const { nostr } = useNostr();
   const { user } = useCurrentUser();
   const [activeTab, setActiveTab] = useState("posts");
+  const [showQRCode, setShowQRCode] = useState(false);
 
   const hash = location.hash.replace('#', '');
 
@@ -890,6 +893,17 @@ export default function Profile() {
             </Button>
           )}
 
+          {/* QR Code button */}
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => setShowQRCode(true)}
+          >
+            <QrCode className="h-4 w-4" />
+            QR Code
+          </Button>
+
           {/* Edit Profile button - only for current user */}
           {isCurrentUser && (
             <Button
@@ -906,6 +920,14 @@ export default function Profile() {
           )}
         </div>
       </div>
+
+      {/* QR Code Modal */}
+      <QRCodeModal
+        isOpen={showQRCode}
+        onClose={() => setShowQRCode(false)}
+        profileUrl={`${window.location.origin}/profile/${pubkey}`}
+        displayName={displayNameFull}
+      />
 
       <Tabs value={activeTab} defaultValue="posts" onValueChange={(value) => {
         setActiveTab(value);


### PR DESCRIPTION
This PR adds QR code functionality to make it easier to share profile and group pages.

## Changes Made:

### Profile Pages
- Added a QR code button in the action buttons section (after Npub and Website buttons)
- QR code modal displays the profile URL with options to copy link or download QR image
- Available for all users viewing any profile

### Group Pages  
- Added a QR code button above the 'Request to Join' button for regular users
- Added a QR code button above the 'Manage Group' button for moderators/owners
- Uses the same QR code modal component as profile pages

## Features:
- **QR Code Generation**: Generates QR codes containing the full page URL
- **Copy Link**: Quick button to copy the URL to clipboard
- **Download QR**: Download the QR code as a PNG image for sharing
- **Consistent UI**: Uses the same modal component across both page types

## Dependencies:
- Added  package for QR code generation

This feature makes it easy for users to share profiles and groups by scanning QR codes with mobile devices or downloading them for use in other materials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a QR code sharing feature to both the Profile and Group Detail pages, allowing users to generate, copy, and download a QR code for their profile or group URL.
  - Introduced a modal dialog for displaying the QR code, with options to copy the link or download the QR code as a PNG image.

- **Chores**
  - Added a new dependency to support QR code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->