### PR TITLE
Add group guidelines to group

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -5,6 +5,7 @@ import NotFound from "./pages/NotFound";
 import Groups from "./pages/Groups";
 import GroupDetail from "./pages/GroupDetail";
 import GroupSettings from "./pages/GroupSettings";
+import GroupGuidelines from "./pages/GroupGuidelines";
 import CreateGroup from "./pages/CreateGroup";
 import Profile from "./pages/Profile";
 import ProfileSettings from "./pages/settings/ProfileSettings";
@@ -23,6 +24,7 @@ export function AppRouter() {
         <Route path="/groups" element={<Groups />} />
         <Route path="/group/:groupId" element={<GroupDetail />} />
         <Route path="/group/:groupId/settings" element={<GroupSettings />} />
+        <Route path="/group/:groupId/guidelines" element={<GroupGuidelines />} />
         <Route path="/create-group" element={<CreateGroup />} />
         <Route path="/profile/:pubkey" element={<Profile />} />
         <Route path="/settings" element={<Settings />} />

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -21,7 +21,7 @@ import { SimpleMembersList } from "@/components/groups/SimpleMembersList";
 import { GroupNutzapButton } from "@/components/groups/GroupNutzapButton";
 import { GroupNutzapTotal } from "@/components/groups/GroupNutzapTotal";
 import { GroupNutzapList } from "@/components/groups/GroupNutzapList";
-import { Users, Settings, MessageSquare, CheckCircle, DollarSign, QrCode } from "lucide-react";
+import { Users, Settings, MessageSquare, CheckCircle, DollarSign, QrCode, FileText } from "lucide-react";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 import Header from "@/components/ui/Header";
 import { QRCodeModal } from "@/components/QRCodeModal";
@@ -124,11 +124,12 @@ export default function GroupDetail() {
   const nameTag = community?.tags.find(tag => tag[0] === "name");
   const descriptionTag = community?.tags.find(tag => tag[0] === "description");
   const imageTag = community?.tags.find(tag => tag[0] === "image");
-
+  const guidelinesTag = community?.tags.find(tag => tag[0] === "guidelines");
 
   const name = nameTag ? nameTag[1] : (parsedId?.identifier || "Unnamed Group");
   const description = descriptionTag ? descriptionTag[1] : "No description available";
   const image = imageTag ? imageTag[1] : undefined;
+  const hasGuidelines = guidelinesTag && guidelinesTag[1].trim().length > 0;
 
   useEffect(() => {
     if (name && name !== "Unnamed Group") {
@@ -192,6 +193,19 @@ export default function GroupDetail() {
             <div className="flex flex-row items-start justify-between gap-4 mb-2">
               <div className="flex flex-col gap-1">
                 <h1 className="text-2xl font-bold">{name}</h1>
+                {hasGuidelines && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    asChild
+                    className="self-start p-1 h-auto text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-md"
+                  >
+                    <Link to={`/group/${encodeURIComponent(groupId || '')}/guidelines`} className="flex items-center gap-1.5">
+                      <FileText className="h-3.5 w-3.5" />
+                      View Guidelines
+                    </Link>
+                  </Button>
+                )}
               </div>
               <div className="flex items-center gap-2">
                 {/* Manage Group button moved to the right column */}

--- a/src/pages/GroupGuidelines.tsx
+++ b/src/pages/GroupGuidelines.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft, FileText } from "lucide-react";
+import { parseNostrAddress } from "@/lib/nostr-utils";
+import Header from "@/components/ui/Header";
+
+export default function GroupGuidelines() {
+  const { groupId } = useParams<{ groupId: string }>();
+  const { nostr } = useNostr();
+  const [parsedId, setParsedId] = useState<{ kind: number; pubkey: string; identifier: string } | null>(null);
+
+  useEffect(() => {
+    if (groupId) {
+      const parsed = parseNostrAddress(decodeURIComponent(groupId));
+      if (parsed) {
+        setParsedId(parsed);
+      }
+    }
+  }, [groupId]);
+
+  const { data: community, isLoading: isLoadingCommunity } = useQuery({
+    queryKey: ["community", parsedId?.pubkey, parsedId?.identifier],
+    queryFn: async (c) => {
+      if (!parsedId) throw new Error("Invalid community ID");
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      const events = await nostr.query([{
+        kinds: [34550],
+        authors: [parsedId.pubkey],
+        "#d": [parsedId.identifier]
+      }], { signal });
+
+      if (events.length === 0) throw new Error("Community not found");
+      return events[0];
+    },
+    enabled: !!nostr && !!parsedId,
+  });
+
+  const nameTag = community?.tags.find(tag => tag[0] === "name");
+  const descriptionTag = community?.tags.find(tag => tag[0] === "description");
+  const imageTag = community?.tags.find(tag => tag[0] === "image");
+  const guidelinesTag = community?.tags.find(tag => tag[0] === "guidelines");
+
+  const name = nameTag ? nameTag[1] : (parsedId?.identifier || "Unnamed Group");
+  const description = descriptionTag ? descriptionTag[1] : "No description available";
+  const image = imageTag ? imageTag[1] : undefined;
+  const guidelines = guidelinesTag ? guidelinesTag[1] : "";
+
+  useEffect(() => {
+    if (name && name !== "Unnamed Group") {
+      document.title = `+chorus - ${name} - Guidelines`;
+    } else {
+      document.title = "+chorus - Guidelines";
+    }
+    return () => {
+      document.title = "+chorus";
+    };
+  }, [name]);
+
+  if (isLoadingCommunity || !parsedId) {
+    return (
+      <div className="container mx-auto py-1 px-3 sm:px-4">
+        <Header />
+        <h1 className="text-2xl font-bold mb-4">Loading guidelines...</h1>
+      </div>
+    );
+  }
+
+  if (!community) {
+    return (
+      <div className="container mx-auto py-1 px-3 sm:px-4">
+        <Header />
+        <h1 className="text-2xl font-bold mb-4">Group not found</h1>
+        <p>The group you're looking for doesn't exist or has been deleted.</p>
+        <Button asChild className="mt-2">
+          <Link to="/groups">Back to Groups</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-1 px-3 sm:px-4">
+      <Header />
+
+      <div className="flex mb-6">
+        <Button variant="ghost" asChild className="p-0 text-2xl">
+          <Link to={`/group/${encodeURIComponent(groupId || "")}`} className="flex flex-row items-center text-2xl font-bold">
+            <ArrowLeft size={40} className="mr-3 w-10 h-10 shrink-0" />
+            Back to Group
+          </Link>
+        </Button>
+      </div>
+
+      <div className="relative mb-6 mt-4">
+        <div className="flex gap-4">
+          <div className="flex-1">
+            <div className="h-36 rounded-lg overflow-hidden mb-2 relative">
+              {image ? (
+                <img
+                  src={image}
+                  alt={name}
+                  className="w-full h-full object-cover object-center"
+                  onError={(e) => {
+                    e.currentTarget.style.display = "none";
+                    const fallback = e.currentTarget.nextElementSibling as HTMLElement;
+                    if (fallback) fallback.style.display = "flex";
+                  }}
+                />
+              ) : null}
+              <div 
+                className={`w-full h-full bg-primary/10 text-primary font-bold text-4xl flex items-center justify-center ${image ? 'hidden' : 'flex'}`}
+              >
+                {name.charAt(0).toUpperCase()}
+              </div>
+            </div>
+
+            <div className="flex flex-row items-start justify-between gap-4 mb-2">
+              <div className="flex flex-col gap-1">
+                <h1 className="text-2xl font-bold">{name}</h1>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        {/* Group description */}
+        <div className="w-full mt-2">
+          <p className="text-base text-muted-foreground">{description}</p>
+        </div>
+      </div>
+
+      <Card className="max-w-4xl mx-auto">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Community Guidelines
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {guidelines ? (
+            <div className="prose prose-sm max-w-none">
+              <div className="whitespace-pre-wrap text-sm leading-relaxed bg-muted/30 p-4 rounded-lg border">
+                {guidelines}
+              </div>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-muted-foreground">
+              <FileText className="h-12 w-12 mx-auto mb-3 opacity-20" />
+              <p className="text-lg font-medium mb-2">No guidelines available</p>
+              <p className="text-sm">This group hasn't set up community guidelines yet.</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/GroupGuidelines.tsx
+++ b/src/pages/GroupGuidelines.tsx
@@ -140,15 +140,15 @@ export default function GroupGuidelines() {
       <Card className="max-w-4xl mx-auto">
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle className="flex items-center gap-2">
-              <FileText className="h-5 w-5" />
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <FileText className="h-4 w-4" />
               Community Guidelines
             </CardTitle>
             {isOwner && (
               <Button asChild variant="outline" size="sm">
                 <Link to={`/group/${encodeURIComponent(groupId || '')}/settings`} className="flex items-center gap-2">
                   <Edit className="h-4 w-4" />
-                  Edit Guidelines
+                  Edit
                 </Link>
               </Button>
             )}
@@ -170,7 +170,7 @@ export default function GroupGuidelines() {
                 <Button asChild variant="outline">
                   <Link to={`/group/${encodeURIComponent(groupId || '')}/settings`} className="flex items-center gap-2">
                     <Edit className="h-4 w-4" />
-                    Add Guidelines
+                    Edit
                   </Link>
                 </Button>
               )}

--- a/src/pages/GroupGuidelines.tsx
+++ b/src/pages/GroupGuidelines.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useNostr } from "@/hooks/useNostr";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ArrowLeft, FileText } from "lucide-react";
+import { ArrowLeft, FileText, Edit } from "lucide-react";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 import Header from "@/components/ui/Header";
 
 export default function GroupGuidelines() {
   const { groupId } = useParams<{ groupId: string }>();
   const { nostr } = useNostr();
+  const { user } = useCurrentUser();
   const [parsedId, setParsedId] = useState<{ kind: number; pubkey: string; identifier: string } | null>(null);
 
   useEffect(() => {
@@ -49,6 +51,8 @@ export default function GroupGuidelines() {
   const description = descriptionTag ? descriptionTag[1] : "No description available";
   const image = imageTag ? imageTag[1] : undefined;
   const guidelines = guidelinesTag ? guidelinesTag[1] : "";
+
+  const isOwner = user && community && user.pubkey === community.pubkey;
 
   useEffect(() => {
     if (name && name !== "Unnamed Group") {
@@ -135,10 +139,20 @@ export default function GroupGuidelines() {
 
       <Card className="max-w-4xl mx-auto">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <FileText className="h-5 w-5" />
-            Community Guidelines
-          </CardTitle>
+          <div className="flex items-center justify-between">
+            <CardTitle className="flex items-center gap-2">
+              <FileText className="h-5 w-5" />
+              Community Guidelines
+            </CardTitle>
+            {isOwner && (
+              <Button asChild variant="outline" size="sm">
+                <Link to={`/group/${encodeURIComponent(groupId || '')}/settings`} className="flex items-center gap-2">
+                  <Edit className="h-4 w-4" />
+                  Edit Guidelines
+                </Link>
+              </Button>
+            )}
+          </div>
         </CardHeader>
         <CardContent>
           {guidelines ? (
@@ -151,7 +165,15 @@ export default function GroupGuidelines() {
             <div className="text-center py-8 text-muted-foreground">
               <FileText className="h-12 w-12 mx-auto mb-3 opacity-20" />
               <p className="text-lg font-medium mb-2">No guidelines available</p>
-              <p className="text-sm">This group hasn't set up community guidelines yet.</p>
+              <p className="text-sm mb-4">This group hasn't set up community guidelines yet.</p>
+              {isOwner && (
+                <Button asChild variant="outline">
+                  <Link to={`/group/${encodeURIComponent(groupId || '')}/settings`} className="flex items-center gap-2">
+                    <Edit className="h-4 w-4" />
+                    Add Guidelines
+                  </Link>
+                </Button>
+              )}
             </div>
           )}
         </CardContent>

--- a/src/pages/GroupGuidelines.tsx
+++ b/src/pages/GroupGuidelines.tsx
@@ -143,7 +143,7 @@ export default function GroupGuidelines() {
         <CardContent>
           {guidelines ? (
             <div className="prose prose-sm max-w-none">
-              <div className="whitespace-pre-wrap text-sm leading-relaxed bg-muted/30 p-4 rounded-lg border">
+              <div className="whitespace-pre-wrap text-sm leading-relaxed">
                 {guidelines}
               </div>
             </div>


### PR DESCRIPTION
fixes #228 

![Screenshot from 2025-05-23 13-05-42](https://github.com/user-attachments/assets/b4f0e0ef-19ca-4aff-a2b3-466cff3d619e)

![Screenshot from 2025-05-23 13-07-15](https://github.com/user-attachments/assets/5645b45c-15cb-44e7-8ff5-a6c19e9d22af)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Group Guidelines page accessible from group details, allowing users to view community guidelines for each group.
  - Introduced a "View Guidelines" button on group pages when guidelines are available, linking directly to the new guidelines page.
  - Group owners can access edit options for guidelines directly from the guidelines page.

- **Bug Fixes**
  - Improved error handling for group images, displaying a fallback initial if the image fails to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->