### PR TITLE
UI improvements: Hide bash.00 zaps, move QR/Guidelines buttons, remove npub button

### DIFF
--- a/src/components/groups/GroupNutzapButton.tsx
+++ b/src/components/groups/GroupNutzapButton.tsx
@@ -164,10 +164,10 @@ export function GroupNutzapButton({
       <Button
         variant={variant}
         size={size}
-        className={cn("w-full h-full justify-start pl-3", className)}
+        className={cn("w-full h-full justify-start pl-3 text-xs", className)}
         onClick={handleOpenDialog}
       >
-        <DollarSign className="h-4 w-4 mr-2" />
+        <DollarSign className="h-4 w-4 mr-1" />
         Send eCash
       </Button>
 

--- a/src/components/groups/GroupNutzapTotal.tsx
+++ b/src/components/groups/GroupNutzapTotal.tsx
@@ -42,16 +42,16 @@ export function GroupNutzapTotal({ groupId, className = "" }: GroupNutzapTotalPr
     <button
       type="button"
       onClick={() => toggleCurrency()}
-      className={`flex items-center w-full h-full text-amber-500 hover:text-amber-600 transition-colors cursor-pointer border border-input rounded-md pl-3 pr-3 py-1.5 bg-transparent hover:bg-accent/50 text-sm ${className}`}
+      className={`flex items-center w-full h-full text-amber-500 hover:text-amber-600 transition-colors cursor-pointer border border-input rounded-md pl-3 pr-3 py-1.5 bg-transparent hover:bg-accent/50 text-xs ${className}`}
       title="Click to toggle between USD and sats"
     >
       <div className="flex items-center">
         {showSats ? (
-          <Bitcoin className="h-4 w-4 mr-4" />
+          <Bitcoin className="h-4 w-4 mr-1" />
         ) : (
-          <DollarSign className="h-4 w-4 mr-4" />
+          <DollarSign className="h-4 w-4 mr-1" />
         )}
-        <span className={`text-sm tabular-nums ${isFlashing ? 'flash-update' : ''}`}>
+        <span className={`text-xs tabular-nums ${isFlashing ? 'flash-update' : ''}`}>
           {currentValue}
         </span>
       </div>

--- a/src/components/groups/JoinRequestButton.tsx
+++ b/src/components/groups/JoinRequestButton.tsx
@@ -119,8 +119,8 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
 
   if (!user) {
     return (
-      <Button variant="outline" disabled className={cn("w-full h-full justify-start pl-3", className)}>
-        <UserPlus className="h-4 w-4 mr-2" />
+      <Button variant="outline" disabled className={cn("w-full h-full justify-start pl-3 text-xs", className)}>
+        <UserPlus className="h-4 w-4 mr-1" />
         <span className="text-left">Log in to join</span>
       </Button>
     );
@@ -128,8 +128,8 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
 
   if (isCheckingRequest || isCheckingApproval || isCheckingDeclined) {
     return (
-      <Button variant="outline" disabled className={cn("w-full h-full justify-start pl-3", className)}>
-        <Clock className="h-4 w-4 mr-2 animate-spin" />
+      <Button variant="outline" disabled className={cn("w-full h-full justify-start pl-3 text-xs", className)}>
+        <Clock className="h-4 w-4 mr-1 animate-spin" />
         Checking status...
       </Button>
     );
@@ -138,8 +138,8 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
   // If user is in both approved and declined lists, treat them as approved
   if (isApprovedMember) {
     return (
-      <Button variant="outline" disabled className={cn("text-green-600 border-green-600 w-full h-full justify-start pl-3", className)}>
-        <CheckCircle className="h-4 w-4 mr-2" />
+      <Button variant="outline" disabled className={cn("text-green-600 border-green-600 w-full h-full justify-start pl-3 text-xs", className)}>
+        <CheckCircle className="h-4 w-4 mr-1" />
         Member
       </Button>
     );
@@ -147,8 +147,8 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
 
   if (existingRequest) {
     return (
-      <Button variant="outline" disabled className={cn("w-full h-full justify-start pl-3", className)}>
-        <Clock className="h-4 w-4 mr-2" />
+      <Button variant="outline" disabled className={cn("w-full h-full justify-start pl-3 text-xs", className)}>
+        <Clock className="h-4 w-4 mr-1" />
         Request pending
       </Button>
     );
@@ -156,8 +156,8 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
   
   if (isDeclinedUser) {
     return (
-      <Button variant="outline" disabled className={cn("text-red-600 border-red-600 w-full h-full justify-start pl-3", className)}>
-        <XCircle className="h-4 w-4 mr-2" />
+      <Button variant="outline" disabled className={cn("text-red-600 border-red-600 w-full h-full justify-start pl-3 text-xs", className)}>
+        <XCircle className="h-4 w-4 mr-1" />
         Request declined
       </Button>
     );
@@ -166,8 +166,8 @@ export function JoinRequestButton({ communityId, isModerator = false, initialOpe
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant="outline" className={cn("w-full h-full justify-start pl-3", className)}>
-          <UserPlus className="h-4 w-4 mr-2" />
+        <Button variant="outline" className={cn("w-full h-full justify-start pl-3 text-xs", className)}>
+          <UserPlus className="h-4 w-4 mr-1" />
           Join
         </Button>
       </DialogTrigger>

--- a/src/components/groups/NutzapButton.tsx
+++ b/src/components/groups/NutzapButton.tsx
@@ -131,7 +131,7 @@ export function NutzapButton({ postId, authorPubkey, relayHint, showText = true,
       ) : (
         <DollarSign className={`h-3.5 w-3.5 ${nutzapTotal > 0 ? 'text-amber-500' : ''}`} />
       )}
-      {showText && <span className="text-xs ml-0.5">{formatAmount(nutzapTotal)}</span>}
+      {showText && nutzapTotal > 0 && <span className="text-xs ml-0.5">{formatAmount(nutzapTotal)}</span>}
     </Button>
   );
 }

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -202,20 +202,21 @@ export default function GroupDetail() {
                   >
                     <QrCode className="h-4 w-4" />
                   </Button>
+                  {hasGuidelines && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      asChild
+                      className="h-8 px-2 text-sm"
+                    >
+                      <Link to={`/group/${encodeURIComponent(groupId || '')}/guidelines`} className="flex items-center gap-1.5">
+                        <FileText className="h-3.5 w-3.5" />
+                        <span className="hidden sm:inline">View Guidelines</span>
+                        <span className="sm:hidden">Guidelines</span>
+                      </Link>
+                    </Button>
+                  )}
                 </div>
-                {hasGuidelines && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    asChild
-                    className="self-start p-1 h-auto text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-md"
-                  >
-                    <Link to={`/group/${encodeURIComponent(groupId || '')}/guidelines`} className="flex items-center gap-1.5">
-                      <FileText className="h-3.5 w-3.5" />
-                      View Guidelines
-                    </Link>
-                  </Button>
-                )}
               </div>
               <div className="flex items-center gap-2">
                 {/* Manage Group button moved to the right column */}

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -192,7 +192,17 @@ export default function GroupDetail() {
 
             <div className="flex flex-row items-start justify-between gap-4 mb-2">
               <div className="flex flex-col gap-1">
-                <h1 className="text-2xl font-bold">{name}</h1>
+                <div className="flex items-center gap-2">
+                  <h1 className="text-2xl font-bold">{name}</h1>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => setShowQRCode(true)}
+                  >
+                    <QrCode className="h-4 w-4" />
+                  </Button>
+                </div>
                 {hasGuidelines && (
                   <Button
                     variant="ghost"
@@ -216,30 +226,12 @@ export default function GroupDetail() {
           <div className="flex flex-col justify-between min-w-[140px] h-36">
             {!isModerator ? (
               <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="gap-1.5 mb-2"
-                  onClick={() => setShowQRCode(true)}
-                >
-                  <QrCode className="h-4 w-4" />
-                  QR Code
-                </Button>
                 <JoinRequestButton communityId={groupId || ''} isModerator={isModerator} />
                 <div className="flex-1" />
                 <GroupNutzapTotal groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`} />
               </>
             ) : (
               <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="gap-1.5 mb-2"
-                  onClick={() => setShowQRCode(true)}
-                >
-                  <QrCode className="h-4 w-4" />
-                  QR Code
-                </Button>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -160,8 +160,8 @@ export default function GroupDetail() {
             <div className="flex-1">
               <Skeleton className="h-40 w-full rounded-lg mb-2" />
             </div>
-            <div className="min-w-[140px]">
-              <Skeleton className="h-10 w-full rounded-md mb-4" />
+            <div className="min-w-[140px] flex flex-col space-y-4">
+              <Skeleton className="h-10 w-full rounded-md" />
               <Skeleton className="h-10 w-full rounded-md" />
             </div>
           </div>
@@ -213,14 +213,13 @@ export default function GroupDetail() {
             </div>
           </div>
 
-          <div className="flex flex-col min-w-[140px] h-40 space-y-2 justify-between">
+          <div className="flex flex-col min-w-[140px] h-40 space-y-2">
             {!isModerator ? (
               <>
                 <div className="h-8">
                   <JoinRequestButton communityId={groupId || ''} isModerator={isModerator} />
                 </div>
-                {/* Add spacer to ensure buttons are distributed evenly */}
-                <div className="flex-1" />
+                {/* If there are more buttons than these, they will flow from top to bottom */}
                 {/* Ensure consistent height for GroupNutzapTotal */}
                 <div className="h-8 flex items-center">
                   <GroupNutzapTotal groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`} />
@@ -228,19 +227,10 @@ export default function GroupDetail() {
               </>
             ) : (
               <>
-                <Button
-                  variant="outline"
-                  size="default"
-                  className="w-full h-8 justify-start pl-3"
-                  onClick={() => setShowQRCode(true)}
-                >
-                  <QrCode className="h-4 w-4 mr-2" />
-                  QR Code
-                </Button>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button asChild variant="outline" size="default" className="relative h-8 w-full justify-start pl-3">
+                      <Button asChild variant="outline" size="default" className="relative h-8 w-full justify-start pl-3 text-xs">
                         <Link
                           to={`/group/${encodeURIComponent(groupId || '')}/settings${
                             openReportsCount > 0 ? '?tab=reports' :
@@ -248,7 +238,7 @@ export default function GroupDetail() {
                           }`}
                           className="flex items-center gap-2"
                         >
-                          <Settings className="h-4 w-4 mr-2" />
+                          <Settings className="h-4 w-4 mr-1" />
                           <span>Manage Group</span>
                           {(openReportsCount > 0 || pendingRequestsCount > 0) && (
                             <Badge
@@ -302,27 +292,29 @@ export default function GroupDetail() {
         </div>
 
         <div className="w-full mt-4">
-          <h1 className="text-2xl font-bold mb-2">{name}</h1>
-          <Button
-            variant="outline"
-            size="icon"
-            className="h-8 w-8"
-            onClick={() => setShowQRCode(true)}
-          >
-            <QrCode className="h-4 w-4" />
-          </Button>
+          <div className="flex items-center mb-2">
+            <h1 className="text-2xl font-bold">{name}</h1>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8 ml-2"
+              onClick={() => setShowQRCode(true)}
+            >
+              <QrCode className="h-4 w-4" />
+            </Button>
+          </div>
           {hasGuidelines && (
             <div className="mb-2">
               <Link
                 to={`/group/${encodeURIComponent(groupId || '')}/guidelines`}
-                className="text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm font-medium inline-flex items-center gap-1"
+                className="text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-xs font-medium inline-flex items-center gap-0.5"
               >
                 <FileText className="h-4 w-4" />
                 Community Guidelines
               </Link>
             </div>
           )}
-          <p className="text-sm text-muted-foreground">{description}</p>
+          <p className="text-xs text-muted-foreground">{description}</p>
         </div>
       </div>
 
@@ -334,17 +326,17 @@ export default function GroupDetail() {
         <div className="md:flex md:justify-start">
           <TabsList className="mb-4 w-full md:w-auto grid grid-cols-3 gap-0">
             <TabsTrigger value="posts" className="flex items-center justify-center">
-              <MessageSquare className="h-4 w-4 mr-2" />
+              <MessageSquare className="h-4 w-4 mr-1" />
               Posts
             </TabsTrigger>
 
             <TabsTrigger value="members" className="flex items-center justify-center">
-              <Users className="h-4 w-4 mr-2" />
+              <Users className="h-4 w-4 mr-1" />
               Members
             </TabsTrigger>
 
             <TabsTrigger value="ecash" className="flex items-center justify-center">
-              <DollarSign className="h-4 w-4 mr-2" />
+              <DollarSign className="h-4 w-4 mr-1" />
               Send eCash
             </TabsTrigger>
           </TabsList>
@@ -365,7 +357,7 @@ export default function GroupDetail() {
                 onCheckedChange={setShowOnlyApproved}
               />
               <Label htmlFor="approved-only" className="flex items-center cursor-pointer text-sm">
-                <CheckCircle className="h-3.5 w-3.5 mr-1.5 text-green-500" />
+                <CheckCircle className="h-3.5 w-3.5 mr-1 text-green-500" />
                 Show only approved posts
               </Label>
             </div>

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -292,7 +292,7 @@ export default function GroupDetail() {
         
         {/* Group description moved outside the grid to span full width */}
         <div className="w-full mt-2">
-          <p className="text-base text-muted-foreground">{description}</p>
+          <p className="text-sm text-muted-foreground">{description}</p>
         </div>
       </div>
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -20,7 +20,6 @@ import { NoteContent } from "@/components/NoteContent";
 import { Link } from "react-router-dom";
 import { 
   ExternalLink, 
-  Copy, 
   Users, 
   Pencil,
   Calendar, 
@@ -732,13 +731,6 @@ export default function Profile() {
   // Check if this is the current user's profile
   const isCurrentUser = user && pubkey === user.pubkey;
 
-  const copyPubkeyToClipboard = () => {
-    if (pubkey) {
-      navigator.clipboard.writeText(pubkey);
-      toast.success("Public key copied to clipboard");
-    }
-  };
-
   useEffect(() => {
     if (displayNameFull && displayNameFull !== "Unnamed User") {
       document.title = `+chorus - ${displayNameFull}`;
@@ -871,18 +863,7 @@ export default function Profile() {
 
         {/* Bottom row: Action buttons */}
         <div className="flex flex-wrap gap-2">
-          {/* Npub button - always first */}
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-            onClick={copyPubkeyToClipboard}
-          >
-            <Copy className="h-4 w-4" />
-            Npub
-          </Button>
-          
-          {/* Website button - second if exists */}
+          {/* Website button - first if exists */}
           {website && (
             <Button
               variant="outline"


### PR DESCRIPTION
This PR includes several UI improvements to make the interface cleaner and more intuitive:

## Changes

### 1. Hide bash.00 display on posts with no nutzaps
- Modified the `NutzapButton` component to only show the amount when there are actual zaps
- The zap icon still appears but without the "bash.00" text when there are no zaps
- This reduces visual clutter on posts

### 2. Move QR code button to right of group name
- Relocated the QR code button from the right column to be inline with the group name
- Changed to an icon-only button style for a more compact appearance
- Better visual association between the QR code and the group identity

### 3. Move "View Guidelines" button inline with group name and QR code
- Moved from below the group name to be in the same row
- Changed from ghost to outline variant to match the QR code button
- Made responsive with full text on larger screens and abbreviated on mobile

### 4. Make group description text smaller
- Changed from `text-base` to `text-sm` for better visual hierarchy
- Makes the description less prominent compared to the group name

### 5. Remove npub button from user profile page
- Removed the "Npub" button that copied the public key to clipboard
- Cleaned up unused functions and imports
- Simplified the profile action buttons for a cleaner interface

## Screenshots
These changes create a cleaner, more intuitive user interface while maintaining all essential functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved layout and alignment of group header elements, consolidating QR code access and enhancing button styles for better usability and responsiveness.
  - Reduced group description text size for a cleaner appearance.

- **Bug Fixes**
  - The nutzap total amount is now only displayed when it is greater than zero, preventing unnecessary display of zero values.

- **New Features**
  - "View Guidelines" button now appears next to the QR code button only when guidelines exist.

- **Chores**
  - Removed the "Npub" button and the ability to copy the public key from the profile actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->