### PR TITLE
Cashu: do not double claim onboarding token

### DIFF
--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -149,10 +149,14 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
         <DropdownMenuItem
           onClick={() => {
             removeLogin(currentUser.id);
-            navigate("/");
-            removeLogin(currentUser.id);
-            navigate("/");
             cashuStore.clearStore();
+            const chorusOnboardingStored =
+              localStorage.getItem("chorus-onboarding");
+            localStorage.clear();
+            if (chorusOnboardingStored) {
+              localStorage.setItem("chorus-onboarding", chorusOnboardingStored);
+            }
+            navigate("/");
           }}
           className="flex items-center gap-2 cursor-pointer p-1.5 rounded-md text-red-500 text-sm md:gap-2 gap-3"
         >

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -152,7 +152,6 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
             navigate("/");
             removeLogin(currentUser.id);
             navigate("/");
-            localStorage.clear();
             cashuStore.clearStore();
           }}
           className="flex items-center gap-2 cursor-pointer p-1.5 rounded-md text-red-500 text-sm md:gap-2 gap-3"

--- a/src/pages/CashuWallet.tsx
+++ b/src/pages/CashuWallet.tsx
@@ -11,6 +11,7 @@ import { Separator } from "@/components/ui/separator";
 import { useCashuToken } from "@/hooks/useCashuToken";
 import { useCashuWallet } from "@/hooks/useCashuWallet";
 import { useCashuStore } from "@/stores/cashuStore";
+import { useOnboardingStore } from "@/stores/onboardingStore";
 import { useToast } from "@/hooks/useToast";
 import { Loader2 } from "lucide-react";
 // import { formatUSD, satoshisToUSD } from "@/lib/bitcoinUtils";
@@ -24,6 +25,7 @@ export function CashuWallet() {
   const { receiveToken } = useCashuToken();
   const { toast } = useToast();
   const cashuStore = useCashuStore();
+  const onboardingStore = useOnboardingStore();
   const [isProcessingToken, setIsProcessingToken] = useState(false);
   const { showSats, toggleCurrency } = useCurrencyDisplayStore();
   const { data: btcPrice, isLoading: btcPriceLoading } = useBitcoinPrice();
@@ -52,6 +54,13 @@ export function CashuWallet() {
     // Check for pending onboarding token
     const pendingToken = cashuStore.getPendingOnboardingToken();
     if (pendingToken) {
+      // Check if already claimed
+      if (onboardingStore.isTokenClaimed()) {
+        // Clear the pending token without processing
+        cashuStore.setPendingOnboardingToken(undefined);
+        return;
+      }
+
       // If USD mode and price is still loading, wait
       if (!showSats && btcPriceLoading) {
         return;
@@ -69,6 +78,9 @@ export function CashuWallet() {
 
           // Calculate total amount
           const totalAmount = proofs.reduce((sum, p) => sum + p.amount, 0);
+
+          // Mark onboarding token as claimed
+          onboardingStore.setTokenClaimed(true);
 
           // Show success toast
           toast({
@@ -96,6 +108,7 @@ export function CashuWallet() {
     user,
     wallet,
     cashuStore,
+    onboardingStore,
     receiveToken,
     toast,
     showSats,

--- a/src/stores/onboardingStore.ts
+++ b/src/stores/onboardingStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface OnboardingStore {
+  tokenClaimed: boolean;
+  setTokenClaimed: (claimed: boolean) => void;
+  isTokenClaimed: () => boolean;
+}
+
+// This store is separate from the main cashu store to ensure
+// the onboarding token claimed state persists across logouts
+export const useOnboardingStore = create<OnboardingStore>()(
+  persist(
+    (set, get) => ({
+      tokenClaimed: false,
+      
+      setTokenClaimed(claimed: boolean) {
+        set({ tokenClaimed: claimed });
+      },
+      
+      isTokenClaimed() {
+        return get().tokenClaimed;
+      },
+    }),
+    { 
+      name: 'chorus-onboarding',
+      // This ensures the data persists even when other stores are cleared
+    }
+  )
+);


### PR DESCRIPTION
Todo: delete all localstorage, but keep only the cashu-onboarding entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logout behavior to preserve onboarding progress data in local storage.
  - Prevented re-processing of onboarding tokens that have already been claimed, reducing duplicate actions and potential errors.

- **New Features**
  - Added persistent tracking of onboarding token claim status to enhance onboarding flow management.

- **Style**
  - Minor formatting adjustments to onboarding headings for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->