### PR TITLE
Cashu: show the balance on top

### DIFF
--- a/src/components/BalanceDisplay.tsx
+++ b/src/components/BalanceDisplay.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect, useRef } from 'react';
+import { Bitcoin, DollarSign } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useCashuStore } from '@/stores/cashuStore';
+import { useCurrencyDisplayStore } from '@/stores/currencyDisplayStore';
+import { calculateBalance, formatBalance } from '@/lib/cashu';
+import { useBitcoinPrice, satsToUSD, formatUSD } from '@/hooks/useBitcoinPrice';
+import { cn } from '@/lib/utils';
+
+export function BalanceDisplay() {
+  const cashuStore = useCashuStore();
+  const { showSats, toggleCurrency } = useCurrencyDisplayStore();
+  const { data: btcPrice } = useBitcoinPrice();
+  const [isFlashing, setIsFlashing] = useState(false);
+  const prevBalance = useRef<string>('');
+
+  // Calculate total balance across all mints
+  const balances = calculateBalance(cashuStore.proofs);
+  const totalBalance = Object.values(balances).reduce((sum, balance) => sum + balance, 0);
+
+  // Format balance based on currency preference
+  const displayBalance = showSats 
+    ? formatBalance(totalBalance)
+    : btcPrice 
+      ? formatUSD(satsToUSD(totalBalance, btcPrice.USD))
+      : formatBalance(totalBalance);
+
+  // Track balance changes for flash effect
+  useEffect(() => {
+    if (prevBalance.current && prevBalance.current !== displayBalance) {
+      setIsFlashing(true);
+      setTimeout(() => setIsFlashing(false), 300);
+    }
+    prevBalance.current = displayBalance;
+  }, [displayBalance]);
+
+  // Don't show balance if user has no wallet
+  if (cashuStore.mints.length === 0) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={toggleCurrency}
+      className={cn(
+        "flex items-center gap-1.5 px-3 py-1.5 font-medium transition-all",
+        isFlashing && "flash-update"
+      )}
+    >
+      {showSats ? (
+        <Bitcoin className="w-3.5 h-3.5 text-orange-500" />
+      ) : (
+        <DollarSign className="w-3.5 h-3.5 text-green-600" />
+      )}
+      <span className="tabular-nums">{displayBalance}</span>
+    </Button>
+  );
+}

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -13,6 +13,7 @@ import {
   Bell,
   Wallet,
   Info,
+  Download,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -30,6 +31,9 @@ import { useLoggedInAccounts } from "@/hooks/useLoggedInAccounts";
 import { useNavigate } from "react-router-dom";
 import { useUnreadNotificationsCount } from "@/hooks/useNotifications";
 import { useCashuStore } from "@/stores/cashuStore";
+import { useState } from "react";
+import { PWAInstallInstructions } from "@/components/PWAInstallInstructions";
+import { usePWA } from "@/hooks/usePWA";
 interface AccountSwitcherProps {
   onAddAccountClick: () => void;
 }
@@ -40,11 +44,27 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
   const navigate = useNavigate();
   const unreadCount = useUnreadNotificationsCount();
   const cashuStore = useCashuStore();
+  const [showInstallInstructions, setShowInstallInstructions] = useState(false);
+  const { isInstallable, isRunningAsPwa, promptInstall } = usePWA();
+
+  const handleInstallClick = async () => {
+    if (isInstallable) {
+      const success = await promptInstall();
+      if (!success) {
+        // If auto-install failed, show instructions
+        setShowInstallInstructions(true);
+      }
+    } else {
+      // Show instructions for manual installation
+      setShowInstallInstructions(true);
+    }
+  };
 
   if (!currentUser) return null;
 
   return (
-    <DropdownMenu>
+    <>
+      <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
@@ -145,6 +165,18 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
             <span>About +chorus</span>
           </a>
         </DropdownMenuItem>
+        {!isRunningAsPwa && (
+          <>
+            <DropdownMenuSeparator className="my-1" />
+            <DropdownMenuItem
+              onClick={handleInstallClick}
+              className="flex items-center gap-2 cursor-pointer p-1.5 rounded-md text-sm md:gap-2 gap-3"
+            >
+              <Download className="w-3.5 h-3.5 md:w-3.5 md:h-3.5 w-4 h-4" />
+              <span>Install App</span>
+            </DropdownMenuItem>
+          </>
+        )}
         <DropdownMenuSeparator className="my-1" />
         <DropdownMenuItem
           onClick={() => {
@@ -165,5 +197,11 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+    
+    <PWAInstallInstructions
+      isOpen={showInstallInstructions}
+      onClose={() => setShowInstallInstructions(false)}
+    />
+    </>
   );
 }

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,5 +1,5 @@
 import { LoginArea } from "@/components/auth/LoginArea";
-import { PWAInstallButton } from "@/components/PWAInstallButton";
+import { BalanceDisplay } from "@/components/BalanceDisplay";
 import type React from "react";
 import { Link } from "react-router-dom";
 
@@ -16,7 +16,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => (
       </h1>
     </Link>
     <div className="flex items-center gap-2">
-      <PWAInstallButton variant="ghost" size="sm" className="hidden sm:flex" />
+      <BalanceDisplay />
       <LoginArea />
     </div>
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a balance display to the header, showing the user's total balance across all wallets, with the ability to toggle between satoshis and USD.
- **Enhancements**
  - Improved the account switcher with an option to install the app as a Progressive Web App (PWA), including manual installation instructions if automatic installation is unavailable.
- **UI Updates**
  - Replaced the PWA install button in the header with the new balance display for improved visibility of account balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->