### PR TITLE
Improve how another user's groups look when you view their profile

### DIFF
--- a/GROUP_ROLE_UI_IMPROVEMENTS.md
+++ b/GROUP_ROLE_UI_IMPROVEMENTS.md
@@ -1,0 +1,65 @@
+# Group Role UI Improvements
+
+## Summary of Changes
+
+The UI for displaying group roles when viewing another user's profile has been significantly improved for better clarity and modern aesthetics.
+
+### Key Improvements:
+
+1. **Clearer Role Display in Common Groups**
+   - Replaced confusing "You:" and "Them:" labels with user avatars and names
+   - Each user's role is displayed next to their avatar for immediate visual association
+   - Roles are shown in a subtle background container for better visual grouping
+
+2. **Consistent Role Badge Design with Avatar Context**
+   - Unified role badge styling across all sections
+   - Added clear icons: Crown (👑) for Owner, Shield (🛡️) for Moderator
+   - **NEW**: When viewing another user's profile, their mini avatar appears in the role badge for clarity
+   - Regular members don't show a badge to reduce visual clutter
+   - Color-coded badges: Blue for owners, Green for moderators
+
+3. **Improved Visual Hierarchy**
+   - Shared Groups section appears first when viewing another user's profile
+   - All Groups section shows all groups with role badges inline
+   - Groups are sorted by role importance (Owner → Moderator → Member → Alphabetical)
+   - Role badges include user's avatar when viewing their profile to clarify context
+
+4. **Modern UI Elements**
+   - Added hover effects with subtle shadows and border color changes
+   - Arrow indicators appear on hover to indicate clickable items
+   - Larger group avatars (16x16) for better visibility
+   - Group counts displayed as subtle badges
+   - Better spacing and typography
+
+5. **Enhanced Empty States**
+   - More helpful empty state when no groups exist
+   - "Explore Groups" button for current user's empty state
+   - No "Shared Groups" section shown if there are no common groups
+
+### Visual Changes:
+
+- **Before**: Confusing text labels "You: Owner" and "Them: Moderator"
+- **After**: Visual user cards with avatars showing each person's role clearly
+
+- **Before**: Inconsistent role badge styling between sections, unclear whose role is being shown
+- **After**: Unified, modern role badges with icons and mini avatars for context
+
+- **Before**: Flat list of groups
+- **After**: Interactive cards with hover effects and better visual hierarchy
+
+### Technical Implementation:
+
+- Created `CommonGroupsListImproved.tsx` with modern role display
+- Updated `Profile.tsx` to use improved components
+- Enhanced `RoleBadge` component to optionally show user avatars
+- Added proper TypeScript types for better type safety
+- Fixed filtering issues for proper null handling
+- Maintained backward compatibility with existing data structures
+
+#### Role Badge Enhancement
+The `RoleBadge` component now accepts:
+- `userPubkey`: The public key of the user whose role is being displayed
+- `showAvatar`: Boolean to show/hide the user's avatar in the badge
+- Shows avatar only when viewing another user's profile for clarity
+
+The new design provides a cleaner, more intuitive way to understand group relationships between users while maintaining a modern, accessible interface.

--- a/src/components/profile/CommonGroupsList.tsx
+++ b/src/components/profile/CommonGroupsList.tsx
@@ -1,0 +1,362 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Users, Crown, Shield, User } from "lucide-react";
+import type { NostrEvent } from "@nostrify/nostrify";
+import { parseNostrAddress } from "@/lib/nostr-utils";
+
+interface CommonGroup {
+  id: string;
+  name: string;
+  description: string;
+  image: string | undefined;
+  groupEvent: NostrEvent;
+  currentUserRole: "owner" | "moderator" | "member";
+  profileUserRole: "owner" | "moderator" | "member";
+}
+
+interface CommonGroupsListProps {
+  profileUserPubkey: string;
+}
+
+// Helper function to get community ID
+const getCommunityId = (community: NostrEvent) => {
+  const dTag = community.tags.find(tag => tag[0] === "d");
+  return `34550:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+};
+
+// Helper function to determine user's role in a group
+const getUserRole = (group: NostrEvent, userPubkey: string): "owner" | "moderator" | "member" => {
+  // Check if user is the owner (creator) of the group
+  if (group.pubkey === userPubkey) {
+    return "owner";
+  }
+
+  // Check if user is a moderator
+  const moderatorTags = group.tags.filter(
+    tag => tag[0] === "p" && tag[3] === "moderator"
+  );
+  const isModerator = moderatorTags.some(tag => tag[1] === userPubkey);
+  
+  if (isModerator) {
+    return "moderator";
+  }
+
+  return "member";
+};
+
+// Role badge component with different styles for current user vs profile user
+function RoleBadge({ 
+  role, 
+  isCurrentUser, 
+  size = "sm" 
+}: { 
+  role: "owner" | "moderator" | "member"; 
+  isCurrentUser: boolean;
+  size?: "sm" | "xs";
+}) {
+  const getIcon = () => {
+    switch (role) {
+      case "owner":
+        return <Crown className={`${size === "xs" ? "h-2.5 w-2.5" : "h-3 w-3"} mr-1`} />;
+      case "moderator":
+        return <Shield className={`${size === "xs" ? "h-2.5 w-2.5" : "h-3 w-3"} mr-1`} />;
+      case "member":
+        return <User className={`${size === "xs" ? "h-2.5 w-2.5" : "h-3 w-3"} mr-1`} />;
+    }
+  };
+
+  const getVariant = () => {
+    if (isCurrentUser) {
+      // Current user roles - solid colors
+      switch (role) {
+        case "owner":
+          return "default"; // Blue
+        case "moderator":
+          return "secondary"; // Gray
+        case "member":
+          return "outline"; // Outline
+      }
+    } else {
+      // Profile user roles - muted colors
+      switch (role) {
+        case "owner":
+          return "default"; // Blue but will be styled differently
+        case "moderator":
+          return "secondary"; // Gray but will be styled differently  
+        case "member":
+          return "outline"; // Outline but will be styled differently
+      }
+    }
+  };
+
+  const getCustomClasses = () => {
+    if (isCurrentUser) {
+      // Current user - bright, solid colors
+      switch (role) {
+        case "owner":
+          return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 border-blue-200 dark:border-blue-800";
+        case "moderator":
+          return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-800";
+        case "member":
+          return "bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-300 border-gray-300 dark:border-gray-600";
+      }
+    } else {
+      // Profile user - muted, subtle colors
+      switch (role) {
+        case "owner":
+          return "bg-blue-50 text-blue-600 dark:bg-blue-950/20 dark:text-blue-400 border-blue-100 dark:border-blue-900/30";
+        case "moderator":
+          return "bg-green-50 text-green-600 dark:bg-green-950/20 dark:text-green-400 border-green-100 dark:border-green-900/30";
+        case "member":
+          return "bg-gray-50 text-gray-500 dark:bg-gray-900/20 dark:text-gray-400 border-gray-200 dark:border-gray-800/50";
+      }
+    }
+  };
+
+  const roleText = role.charAt(0).toUpperCase() + role.slice(1);
+
+  return (
+    <Badge 
+      variant={getVariant()}
+      className={`${getCustomClasses()} ${size === "xs" ? "text-xs px-1.5 py-0.5 h-5" : "text-xs px-2 py-0.5 h-6"} font-medium flex items-center`}
+    >
+      {getIcon()}
+      {roleText}
+    </Badge>
+  );
+}
+
+export function CommonGroupsList({ profileUserPubkey }: CommonGroupsListProps) {
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+
+  const { data: commonGroups, isLoading } = useQuery({
+    queryKey: ["common-groups", user?.pubkey, profileUserPubkey],
+    queryFn: async (c) => {
+      if (!user || !nostr || !profileUserPubkey || user.pubkey === profileUserPubkey) {
+        return [];
+      }
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(8000)]);
+
+      // Get membership events for both users
+      const [currentUserMemberships, profileUserMemberships] = await Promise.all([
+        nostr.query([{ kinds: [14550], "#p": [user.pubkey], limit: 100 }], { signal }),
+        nostr.query([{ kinds: [14550], "#p": [profileUserPubkey], limit: 100 }], { signal })
+      ]);
+
+      // Get communities owned/moderated by both users
+      const [currentUserCommunities, profileUserCommunities] = await Promise.all([
+        nostr.query([
+          { kinds: [34550], authors: [user.pubkey] },
+          { kinds: [34550], "#p": [user.pubkey] }
+        ], { signal }),
+        nostr.query([
+          { kinds: [34550], authors: [profileUserPubkey] },
+          { kinds: [34550], "#p": [profileUserPubkey] }
+        ], { signal })
+      ]);
+
+      // Extract community IDs for current user
+      const currentUserCommunityIds = new Set<string>();
+      
+      // From memberships
+      for (const membership of currentUserMemberships) {
+        const aTag = membership.tags.find(tag => tag[0] === "a");
+        if (aTag) currentUserCommunityIds.add(aTag[1]);
+      }
+      
+      // From owned/moderated communities
+      for (const community of currentUserCommunities) {
+        const communityId = getCommunityId(community);
+        currentUserCommunityIds.add(communityId);
+      }
+
+      // Extract community IDs for profile user
+      const profileUserCommunityIds = new Set<string>();
+      
+      // From memberships
+      for (const membership of profileUserMemberships) {
+        const aTag = membership.tags.find(tag => tag[0] === "a");
+        if (aTag) profileUserCommunityIds.add(aTag[1]);
+      }
+      
+      // From owned/moderated communities
+      for (const community of profileUserCommunities) {
+        const communityId = getCommunityId(community);
+        profileUserCommunityIds.add(communityId);
+      }
+
+      // Find common community IDs
+      const commonCommunityIds = [...currentUserCommunityIds].filter(id => 
+        profileUserCommunityIds.has(id)
+      );
+
+      if (commonCommunityIds.length === 0) {
+        return [];
+      }
+
+      // Fetch community details for common groups
+      const communityFilters = commonCommunityIds.map(id => {
+        const parts = id.split(":");
+        if (parts.length === 3) {
+          return {
+            kinds: [parseInt(parts[0])],
+            authors: [parts[1]],
+            "#d": [parts[2]]
+          };
+        }
+        return null;
+      }).filter(Boolean);
+
+      if (communityFilters.length === 0) {
+        return [];
+      }
+
+      const communityEvents = await nostr.query(communityFilters, { signal });
+
+      // Build common groups with role information
+      const commonGroups: CommonGroup[] = [];
+
+      for (const event of communityEvents) {
+        const communityId = getCommunityId(event);
+        
+        // Only include if both users are actually members
+        if (currentUserCommunityIds.has(communityId) && profileUserCommunityIds.has(communityId)) {
+          const nameTag = event.tags.find(tag => tag[0] === "name");
+          const descriptionTag = event.tags.find(tag => tag[0] === "description");
+          const imageTag = event.tags.find(tag => tag[0] === "image");
+
+          commonGroups.push({
+            id: communityId,
+            name: nameTag ? nameTag[1] : (event.tags.find(tag => tag[0] === "d")?.[1] || "Unnamed Group"),
+            description: descriptionTag ? descriptionTag[1] : "",
+            image: imageTag ? imageTag[1] : undefined,
+            groupEvent: event,
+            currentUserRole: getUserRole(event, user.pubkey),
+            profileUserRole: getUserRole(event, profileUserPubkey)
+          });
+        }
+      }
+
+      // Sort by name
+      return commonGroups.sort((a, b) => a.name.localeCompare(b.name));
+    },
+    enabled: !!nostr && !!user && !!profileUserPubkey && user.pubkey !== profileUserPubkey,
+  });
+
+  // Don't show anything if viewing own profile
+  if (!user || !profileUserPubkey || user.pubkey === profileUserPubkey) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 mb-4">
+          <Users className="h-5 w-5 text-muted-foreground" />
+          <h3 className="text-lg font-semibold">Groups in Common</h3>
+        </div>
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center gap-3">
+              <Skeleton className="h-12 w-12 rounded-lg" />
+              <div className="flex-1">
+                <Skeleton className="h-4 w-32 mb-1" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!commonGroups || commonGroups.length === 0) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 mb-4">
+          <Users className="h-5 w-5 text-muted-foreground" />
+          <h3 className="text-lg font-semibold">Groups in Common</h3>
+        </div>
+        <div className="p-6 text-center bg-muted/30 rounded-lg">
+          <p className="text-muted-foreground text-sm">No groups in common</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 mb-4">
+        <Users className="h-5 w-5 text-muted-foreground" />
+        <h3 className="text-lg font-semibold">Groups in Common</h3>
+        <Badge variant="secondary" className="text-xs">
+          {commonGroups.length}
+        </Badge>
+      </div>
+      
+      <div className="space-y-3">
+        {commonGroups.map((group) => (
+          <Link
+            key={group.id}
+            to={`/group/${encodeURIComponent(group.id)}`}
+            className="block"
+          >
+            <Card className="overflow-hidden border border-border/40 hover:border-border hover:shadow-sm transition-all duration-200">
+              <div className="flex p-4">
+                <div className="h-12 w-12 rounded-lg overflow-hidden mr-3 flex-shrink-0 bg-muted relative">
+                  {group.image ? (
+                    <img
+                      src={group.image}
+                      alt={group.name}
+                      className="h-full w-full object-cover"
+                      onError={(e) => {
+                        e.currentTarget.style.display = "none";
+                        const fallback = e.currentTarget.nextElementSibling as HTMLElement;
+                        if (fallback) fallback.style.display = "flex";
+                      }}
+                    />
+                  ) : null}
+                  <div 
+                    className={`absolute inset-0 bg-primary/10 text-primary font-bold text-sm flex items-center justify-center ${group.image ? 'hidden' : 'flex'}`}
+                  >
+                    {group.name.charAt(0).toUpperCase()}
+                  </div>
+                </div>
+                
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-start justify-between mb-2">
+                    <h4 className="font-medium text-sm truncate pr-2">{group.name}</h4>
+                  </div>
+                  
+                  {group.description && (
+                    <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
+                      {group.description}
+                    </p>
+                  )}
+                  
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <div className="flex items-center gap-1">
+                      <span className="text-xs text-muted-foreground">You:</span>
+                      <RoleBadge role={group.currentUserRole} isCurrentUser={true} size="xs" />
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <span className="text-xs text-muted-foreground">Them:</span>
+                      <RoleBadge role={group.profileUserRole} isCurrentUser={false} size="xs" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -30,7 +30,11 @@ import {
   LinkIcon,
   MoreVertical,
   Flag,
-  QrCode
+  QrCode,
+  ArrowRight,
+  Crown,
+  Shield,
+  User
 } from "lucide-react";
 import { toast } from "sonner";
 import type { NostrEvent } from "@nostrify/nostrify";
@@ -43,6 +47,7 @@ import { shareContent } from "@/lib/share";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
 import { EmojiReactionButton } from "@/components/EmojiReactionButton";
 import { NutzapButton } from "@/components/groups/NutzapButton";
 import { NutzapInterface } from "@/components/groups/NutzapInterface";
@@ -55,7 +60,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { QRCodeModal } from "@/components/QRCodeModal";
-import { CommonGroupsList } from "@/components/profile/CommonGroupsList";
+import { CommonGroupsListImproved } from "@/components/profile/CommonGroupsListImproved";
 
 // Helper function to extract group information from a post
 function extractGroupInfo(post: NostrEvent): { groupId: string; groupName: string } | null {
@@ -224,6 +229,67 @@ interface UserGroup {
   groupEvent: NostrEvent;
 }
 
+// Modern role badge component with optional avatar
+function RoleBadge({ 
+  role, 
+  size = "default",
+  userPubkey,
+  showAvatar = false
+}: { 
+  role: "owner" | "moderator" | "member";
+  size?: "default" | "sm";
+  userPubkey?: string;
+  showAvatar?: boolean;
+}) {
+  const author = useAuthor(userPubkey);
+  const metadata = showAvatar && userPubkey ? author.data?.metadata : null;
+  
+  const getIcon = () => {
+    const iconSize = size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5";
+    switch (role) {
+      case "owner":
+        return <Crown className={`${iconSize} ${showAvatar ? '' : 'mr-1'}`} />;
+      case "moderator":
+        return <Shield className={`${iconSize} ${showAvatar ? '' : 'mr-1'}`} />;
+      case "member":
+        return null; // No icon for regular members
+    }
+  };
+
+  const getRoleStyles = () => {
+    switch (role) {
+      case "owner":
+        return "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-800";
+      case "moderator":
+        return "bg-green-50 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-300 dark:border-green-800";
+      case "member":
+        return "bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700";
+    }
+  };
+
+  if (role === "member") {
+    return null; // Don't show badge for regular members
+  }
+
+  const roleText = role.charAt(0).toUpperCase() + role.slice(1);
+  const paddingSize = size === "sm" ? "px-1.5 py-0.5" : "px-2 py-0.5";
+
+  return (
+    <div className={`inline-flex items-center gap-1.5 ${paddingSize} text-xs font-medium rounded-md border ${getRoleStyles()}`}>
+      {showAvatar && userPubkey && (
+        <Avatar className="h-4 w-4">
+          <AvatarImage src={metadata?.picture} />
+          <AvatarFallback className="text-[8px]">
+            {metadata?.name?.slice(0, 1).toUpperCase() || userPubkey.slice(0, 1).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+      )}
+      {getIcon()}
+      <span>{roleText}</span>
+    </div>
+  );
+}
+
 function UserGroupsList({
   groups,
   isLoading,
@@ -254,10 +320,16 @@ function UserGroupsList({
 
   if (!groups || groups.length === 0) {
     return (
-      <div className="p-6 text-center bg-muted/30 rounded-lg">
+      <div className="p-8 text-center bg-muted/20 rounded-xl border border-border/50">
+        <Users className="h-12 w-12 mx-auto mb-3 text-muted-foreground/50" />
         <p className="text-muted-foreground">
           {isCurrentUser ? "You are not a member of any groups yet" : "This user is not a member of any groups yet"}
         </p>
+        {isCurrentUser && (
+          <Link to="/groups" className="mt-3 inline-block">
+            <Button variant="outline" size="sm">Explore Groups</Button>
+          </Link>
+        )}
       </div>
     );
   }
@@ -294,35 +366,54 @@ function UserGroupsList({
     return 'member';
   };
 
+  // Sort groups by role (owner first, then moderator, then member)
+  const sortedGroups = Array.from(uniqueGroups.values()).sort((a, b) => {
+    const roleOrder = { owner: 0, moderator: 1, member: 2 };
+    const aRole = getUserRole(a, profileUserPubkey);
+    const bRole = getUserRole(b, profileUserPubkey);
+    
+    if (roleOrder[aRole] !== roleOrder[bRole]) {
+      return roleOrder[aRole] - roleOrder[bRole];
+    }
+    
+    // If same role, sort by name
+    return a.name.localeCompare(b.name);
+  });
+
   return (
     <div className="space-y-6">
       {/* Common Groups Section - only show when viewing another user's profile */}
-      {!isCurrentUser && (
-        <CommonGroupsList profileUserPubkey={profileUserPubkey} />
+      {!isCurrentUser && user && (
+        <CommonGroupsListImproved profileUserPubkey={profileUserPubkey} />
       )}
 
       {/* All Groups Section */}
-      <div className="space-y-3">
-        <div className="flex items-center gap-2">
-          <Users className="h-5 w-5 text-muted-foreground" />
-          <h3 className="text-lg font-semibold">
-            {isCurrentUser ? "Your Groups" : "All Groups"}
-          </h3>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Users className="h-5 w-5 text-primary" />
+            <h3 className="text-lg font-semibold">
+              {isCurrentUser ? "Your Groups" : `${user ? "All " : ""}Groups`}
+            </h3>
+          </div>
+          <Badge variant="secondary" className="text-xs">
+            {uniqueGroups.size} {uniqueGroups.size === 1 ? 'group' : 'groups'}
+          </Badge>
         </div>
         
-        <div className="grid grid-cols-1 gap-4">
-          {Array.from(uniqueGroups.values()).map((group) => {
+        <div className="grid grid-cols-1 gap-3">
+          {sortedGroups.map((group) => {
             const userRole = getUserRole(group, profileUserPubkey);
             
             return (
               <Link
                 key={group.id}
                 to={`/group/${encodeURIComponent(group.id)}`}
-                className="block"
+                className="block group"
               >
-                <Card className="overflow-hidden border border-border/40 hover:border-border hover:shadow-sm transition-all duration-200">
+                <Card className="overflow-hidden hover:shadow-md transition-all duration-200 hover:border-primary/20">
                   <div className="flex p-4">
-                    <div className="h-14 w-14 rounded-lg overflow-hidden mr-4 flex-shrink-0 bg-muted relative">
+                    <div className="h-16 w-16 rounded-lg overflow-hidden mr-4 flex-shrink-0 bg-muted relative">
                       {group.image ? (
                         <img
                           src={group.image}
@@ -336,32 +427,28 @@ function UserGroupsList({
                         />
                       ) : null}
                       <div 
-                        className={`absolute inset-0 bg-primary/10 text-primary font-bold text-lg flex items-center justify-center ${group.image ? 'hidden' : 'flex'}`}
+                        className={`absolute inset-0 bg-primary/10 text-primary font-bold text-xl flex items-center justify-center ${group.image ? 'hidden' : 'flex'}`}
                       >
                         {group.name.charAt(0).toUpperCase()}
                       </div>
                     </div>
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between mb-0.5">
-                        <h3 className="font-medium text-sm">{group.name}</h3>
-                        {userRole !== 'member' && (
-                          <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${
-                            isCurrentUser
-                              ? userRole === 'owner' 
-                                ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
-                                : 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-                              : userRole === 'owner'
-                                ? 'bg-blue-50 text-blue-600 dark:bg-blue-950/20 dark:text-blue-400 border border-blue-100 dark:border-blue-900/30'
-                                : 'bg-green-50 text-green-600 dark:bg-green-950/20 dark:text-green-400 border border-green-100 dark:border-green-900/30'
-                          }`}>
-                            {userRole === 'owner' ? 'Owner' : 'Moderator'}
-                          </span>
-                        )}
+                    <div className="flex-1 flex flex-col justify-center">
+                      <div className="flex items-center gap-2 mb-1">
+                        <h3 className="font-semibold text-base group-hover:text-primary transition-colors">{group.name}</h3>
+                        <RoleBadge 
+                          role={userRole} 
+                          size="sm" 
+                          userPubkey={profileUserPubkey}
+                          showAvatar={!isCurrentUser} 
+                        />
                       </div>
-                      <p className="text-xs leading-snug text-muted-foreground line-clamp-2">
-                        {group.description || "No description available"}
-                      </p>
+                      {group.description && (
+                        <p className="text-sm text-muted-foreground line-clamp-2">
+                          {group.description}
+                        </p>
+                      )}
                     </div>
+                    <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity self-center ml-2" />
                   </div>
                 </Card>
               </Link>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -315,12 +315,14 @@ function RoleBadge({
   role, 
   size = "default",
   userPubkey,
-  showAvatar = false
+  showAvatar = false,
+  simplified = false
 }: { 
   role: "owner" | "moderator" | "member";
   size?: "default" | "sm";
   userPubkey?: string;
   showAvatar?: boolean;
+  simplified?: boolean;
 }) {
   const author = useAuthor(userPubkey);
   const metadata = showAvatar && userPubkey ? author.data?.metadata : null;
@@ -329,9 +331,9 @@ function RoleBadge({
     const iconSize = size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5";
     switch (role) {
       case "owner":
-        return <Crown className={`${iconSize} ${showAvatar ? '' : 'mr-1'}`} />;
+        return <Crown className={`${iconSize} ${showAvatar && !simplified ? '' : 'mr-1'}`} />;
       case "moderator":
-        return <Shield className={`${iconSize} ${showAvatar ? '' : 'mr-1'}`} />;
+        return <Shield className={`${iconSize} ${showAvatar && !simplified ? '' : 'mr-1'}`} />;
       case "member":
         return null; // No icon for regular members
     }
@@ -355,6 +357,22 @@ function RoleBadge({
   const roleText = role.charAt(0).toUpperCase() + role.slice(1);
   const paddingSize = size === "sm" ? "px-1.5 py-0.5" : "px-2 py-0.5";
 
+  // Simplified version: just show avatar and icon
+  if (simplified && showAvatar && userPubkey) {
+    return (
+      <div className={`inline-flex items-center gap-1 ${paddingSize} text-xs font-medium rounded-md border ${getRoleStyles()}`}>
+        <Avatar className="h-4 w-4">
+          <AvatarImage src={metadata?.picture} />
+          <AvatarFallback className="text-[8px]">
+            {metadata?.name?.slice(0, 1).toUpperCase() || userPubkey.slice(0, 1).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        {getIcon()}
+      </div>
+    );
+  }
+
+  // Original version with text
   return (
     <div className={`inline-flex items-center gap-1.5 ${paddingSize} text-xs font-medium rounded-md border ${getRoleStyles()}`}>
       {showAvatar && userPubkey && (
@@ -530,7 +548,8 @@ function UserGroupsList({
                           role={userRole} 
                           size="sm" 
                           userPubkey={profileUserPubkey}
-                          showAvatar={!isCurrentUser} 
+                          showAvatar={!isCurrentUser}
+                          simplified={!isCurrentUser}
                         />
                       </div>
                       {group.description && (

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1239,7 +1239,7 @@ export default function Profile() {
         </TabsContent>
 
         <TabsContent value="groups" className="space-y-4">
-          <div className="max-w-3xl mx-auto">
+          <div className="max-w-3xl mx-auto pb-6">
             <UserGroupsList 
               groups={userGroups} 
               isLoading={isLoadingGroups} 


### PR DESCRIPTION
Fixes #256 

Fixes #254 

![Screenshot from 2025-05-23 16-09-55](https://github.com/user-attachments/assets/96f4e80d-ebc6-4cf7-bf63-f7eb8cddc657)

![Screenshot from 2025-05-23 16-08-24](https://github.com/user-attachments/assets/832ba4cb-8406-4317-8fc0-4a9ab73c280a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a section to user profiles displaying groups shared in common with other users, including each user's role within those groups.
  - Introduced a modernized shared groups display featuring user avatars and role icons for clearer role identification.
- **Enhancements**
  - Improved group list messaging and layout on profile pages, with tailored messages and headers depending on whether you are viewing your own profile or another user's.
  - Updated role badges for clearer distinction between owners, moderators, and members, now optionally showing user avatars.
  - Enhanced group cards with larger images, hover effects, and role badges showing avatars when viewing other users’ profiles.
  - Added an "Explore Groups" button for empty states on the current user’s profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->