### PR TITLE
Remove asterisk from 'vibed by AOS' text in Index page footer

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -222,7 +222,7 @@ const Index = () => {
           {/* Footer attribution */}
           <div className="absolute bottom-4 left-0 right-0 text-center">
             <p className="text-xs text-muted-foreground">
-              *vibed by{" "}
+              vibed by{" "}
               <a
                 href="https://andotherstuff.org"
                 target="_blank"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated footer attribution text by removing the asterisk (*) before "vibed by" for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->