### PR TITLE
Add home icon to header when logged in

### DIFF
--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -24,7 +24,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
 
   return (
     <div className={`flex justify-between items-center ${className || ""}`}>
-      <div className="flex items-end gap-1.5">
+      <div className="flex items-center gap-1.5">
         <Link to="/" className="contents">
           <h1 className="text-2xl font-bold flex flex-row items-center leading-none">
             <span className="text-red-500 font-extrabold text-3xl">+</span>
@@ -32,7 +32,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
           </h1>
         </Link>
         {user && (
-          <Link to="/" className="text-gray-500/60 hover:text-gray-700 dark:text-gray-400/60 dark:hover:text-gray-200 transition-all pb-[2px]">
+          <Link to="/" className="text-gray-500/60 hover:text-gray-700 dark:text-gray-400/60 dark:hover:text-gray-200 transition-all">
             <Home className="w-5 h-5" />
           </Link>
         )}

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -24,7 +24,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
 
   return (
     <div className={`flex justify-between items-center ${className || ""}`}>
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-baseline gap-1.5">
         <Link to="/" className="contents">
           <h1 className="text-2xl font-bold flex flex-row items-center leading-none">
             <span className="text-red-500 font-extrabold text-3xl">+</span>

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -6,6 +6,7 @@ import { useOnboardingStore } from "@/stores/onboardingStore";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type React from "react";
 import { Link } from "react-router-dom";
+import { Home } from "lucide-react";
 
 interface HeaderProps {
   className?: string;
@@ -23,12 +24,19 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
 
   return (
     <div className={`flex justify-between items-center ${className || ""}`}>
-      <Link to="/" className="contents">
-        <h1 className="text-2xl font-bold flex flex-row items-center leading-none">
-          <span className="text-red-500 font-extrabold text-3xl">+</span>
-          chorus
-        </h1>
-      </Link>
+      <div className="flex items-center gap-3">
+        <Link to="/" className="contents">
+          <h1 className="text-2xl font-bold flex flex-row items-center leading-none">
+            <span className="text-red-500 font-extrabold text-3xl">+</span>
+            chorus
+          </h1>
+        </Link>
+        {user && (
+          <Link to="/" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors">
+            <Home className="w-5 h-5" />
+          </Link>
+        )}
+      </div>
       <div className="flex items-center gap-2">
         {showClaimButton ? <ClaimOnboardingTokenButton /> : <BalanceDisplay />}
         <LoginArea />

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -24,7 +24,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
 
   return (
     <div className={`flex justify-between items-center ${className || ""}`}>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-1.5">
         <Link to="/" className="contents">
           <h1 className="text-2xl font-bold flex flex-row items-center leading-none">
             <span className="text-red-500 font-extrabold text-3xl">+</span>
@@ -32,7 +32,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
           </h1>
         </Link>
         {user && (
-          <Link to="/" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors">
+          <Link to="/" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors flex items-center">
             <Home className="w-5 h-5" />
           </Link>
         )}

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -24,7 +24,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
 
   return (
     <div className={`flex justify-between items-center ${className || ""}`}>
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-end gap-1.5">
         <Link to="/" className="contents">
           <h1 className="text-2xl font-bold flex flex-row items-center leading-none">
             <span className="text-red-500 font-extrabold text-3xl">+</span>
@@ -32,7 +32,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
           </h1>
         </Link>
         {user && (
-          <Link to="/" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors flex items-center">
+          <Link to="/" className="text-gray-500/60 hover:text-gray-700 dark:text-gray-400/60 dark:hover:text-gray-200 transition-all pb-[2px]">
             <Home className="w-5 h-5" />
           </Link>
         )}


### PR DESCRIPTION
This PR adds a subtle home icon next to the +chorus logo that appears only when users are logged in.

## Changes
- Added Home icon from lucide-react to the header
- Icon only shows when user is logged in
- Positioned to the right of +chorus with minimal spacing
- Styled with reduced opacity (60%) for subtlety
- Proper hover states for both light and dark modes
- Aligned with text baseline for clean appearance

## Visual Details
- Icon uses gray-500/60 in light mode, gray-400/60 in dark mode
- Smooth transitions on hover
- Baseline alignment ensures icon bottom aligns with 'chorus' text bottom
- Small gap (1.5) between logo and icon for tight integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a Home icon link to the header, visible when logged in, allowing quick navigation to the homepage.

- **Style**
	- Improved header layout with better alignment and spacing for the site title and icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->