### PR TITLE
Move community guidelines link to icon button next to QR code

### DIFF
--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -28,6 +28,8 @@ import { QRCodeModal } from "@/components/QRCodeModal";
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 export default function GroupDetail() {
   const { groupId } = useParams<{ groupId: string }>();
@@ -40,6 +42,7 @@ export default function GroupDetail() {
   const [activeTab, setActiveTab] = useState("posts");
   const [imageLoading, setImageLoading] = useState(true);
   const [showQRCode, setShowQRCode] = useState(false);
+  const [showGuidelines, setShowGuidelines] = useState(false);
 
 
   const searchParams = new URLSearchParams(location.search);
@@ -348,14 +351,12 @@ export default function GroupDetail() {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
-                      asChild
                       variant="outline"
                       size="icon"
                       className="h-8 w-8 ml-1"
+                      onClick={() => setShowGuidelines(true)}
                     >
-                      <Link to={`/group/${encodeURIComponent(groupId || '')}/guidelines`}>
-                        <FileText className="h-4 w-4" />
-                      </Link>
+                      <FileText className="h-4 w-4" />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -453,6 +454,23 @@ export default function GroupDetail() {
         profileUrl={`${window.location.origin}/group/${encodeURIComponent(groupId || '')}`}
         displayName={name}
       />
+
+      {/* Community Guidelines Modal */}
+      <Dialog open={showGuidelines} onOpenChange={setShowGuidelines}>
+        <DialogContent className="max-w-2xl max-h-[80vh]">
+          <DialogHeader>
+            <DialogTitle>Community Guidelines</DialogTitle>
+            <DialogDescription>
+              Guidelines for {name}
+            </DialogDescription>
+          </DialogHeader>
+          <ScrollArea className="mt-4 max-h-[60vh] pr-4">
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              <p className="whitespace-pre-wrap">{guidelinesTag?.[1] || "No guidelines available."}</p>
+            </div>
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
This PR improves the UI by converting the community guidelines link into an icon button positioned next to the QR code button, and makes it open in a modal popup.

## Changes
- Removed the text link for community guidelines below the group name
- Added a new icon button with FileText icon next to the QR code button
- Added tooltips to both QR code and guidelines buttons for better UX
- Converted community guidelines to open in a modal dialog instead of navigating to a new page
- Added proper Dialog components with ScrollArea for long content
- Maintains the same conditional display (only shows when guidelines exist)

## Visual Improvements
- Cleaner layout with both sharing/info buttons grouped together
- Consistent button styling with outline variant
- Proper spacing between buttons (ml-1)
- Tooltips provide context without cluttering the UI
- Modal popup keeps users on the group page for better UX
- Responsive modal sizing with scrollable content area
- Prose styling for better text formatting in guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Community guidelines are now displayed in a modal dialog within the group detail page, accessible via a new icon button.
  - Tooltips have been added to the QR code share and guidelines buttons for improved usability.
- **Style**
  - Guidelines content is presented in a scrollable, styled format for better readability.
- **Refactor**
  - The previous inline link to the guidelines page has been removed in favor of the new modal dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->