### PR TITLE
Improve: eCash tab UI with compact design and consistent width

### DIFF
--- a/src/components/groups/GroupNutzapList.tsx
+++ b/src/components/groups/GroupNutzapList.tsx
@@ -22,20 +22,18 @@ export function GroupNutzapList({ groupId }: GroupNutzapListProps) {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-2">
         {Array.from({ length: 3 }).map((_, i) => (
           <Card key={i}>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Skeleton className="h-10 w-10 rounded-full" />
-                <div className="space-y-2">
-                  <Skeleton className="h-4 w-32" />
+            <CardContent className="p-3">
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-9 w-9 rounded-full flex-shrink-0" />
+                <div className="space-y-1.5 flex-1">
+                  <Skeleton className="h-3.5 w-32" />
                   <Skeleton className="h-3 w-24" />
                 </div>
+                <Skeleton className="h-4 w-20" />
               </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-4 w-full" />
             </CardContent>
           </Card>
         ))}
@@ -50,15 +48,17 @@ export function GroupNutzapList({ groupId }: GroupNutzapListProps) {
   if (!nutzaps || nutzaps.length === 0) {
     return (
       <Card>
-        <CardContent className="pt-6 text-center text-muted-foreground">
-          No eCash for this group yet.
+        <CardContent className="py-8 text-center text-muted-foreground">
+          <Zap className="h-8 w-8 mx-auto mb-2 text-muted-foreground/50" />
+          <p className="text-sm">No eCash sent to this group yet.</p>
+          <p className="text-xs mt-1">Be the first to support!</p>
         </CardContent>
       </Card>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <div className="text-right">
         <button
           onClick={() => toggleCurrency()}
@@ -79,9 +79,11 @@ export function GroupNutzapList({ groupId }: GroupNutzapListProps) {
           )}
         </button>
       </div>
-      {nutzaps.map((event) => (
-        <NutzapItem key={event.id} event={event} btcPrice={btcPrice?.USD} showSats={showSats} />
-      ))}
+      <div className="space-y-2">
+        {nutzaps.map((event) => (
+          <NutzapItem key={event.id} event={event} btcPrice={btcPrice?.USD} showSats={showSats} />
+        ))}
+      </div>
     </div>
   );
 }
@@ -124,36 +126,36 @@ function NutzapItem({ event, btcPrice, showSats }: { event: NostrEvent; btcPrice
   }, [currentValue, showSats]);
 
   return (
-    <Card>
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between">
-          <Link to={`/profile/${event.pubkey}`} className="flex items-center gap-2 hover:underline">
-            <Avatar className="h-10 w-10">
+    <Card className="hover:bg-accent/50 transition-colors">
+      <CardContent className="p-3">
+        <div className="flex items-center justify-between gap-3">
+          <Link to={`/profile/${event.pubkey}`} className="flex items-center gap-3 min-w-0 hover:opacity-80 transition-opacity">
+            <Avatar className="h-9 w-9 flex-shrink-0">
               <AvatarImage src={profileImage} />
-              <AvatarFallback>{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
+              <AvatarFallback className="text-xs">{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
             </Avatar>
-            <div>
-              <div className="font-medium">{displayName}</div>
+            <div className="min-w-0">
+              <div className="font-medium text-sm truncate">{displayName}</div>
               <div className="text-xs text-muted-foreground">{formattedDate}</div>
             </div>
           </Link>
-          <div className="flex items-center">
+          <div className="flex items-center flex-shrink-0">
             {showSats ? (
               <Bitcoin className="h-4 w-4 mr-1 text-amber-500" />
             ) : (
               <DollarSign className="h-4 w-4 mr-1 text-green-500" />
             )}
-            <span className={`font-medium tabular-nums ${isFlashing ? 'flash-update' : ''}`}>
+            <span className={`font-semibold tabular-nums text-sm ${isFlashing ? 'flash-update' : ''}`}>
               {currentValue}
             </span>
           </div>
         </div>
-      </CardHeader>
-      {event.content && (
-        <CardContent>
-          <p className="text-sm">{event.content}</p>
-        </CardContent>
-      )}
+        {event.content && (
+          <div className="mt-2 pl-12">
+            <p className="text-sm text-muted-foreground line-clamp-2">{event.content}</p>
+          </div>
+        )}
+      </CardContent>
     </Card>
   );
 }

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -405,19 +405,21 @@ export default function GroupDetail() {
         </TabsContent>
 
         <TabsContent value="ecash" className="space-y-4">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-xl font-semibold">Group eCash</h2>
-            {user && community && (
-              <div className="flex-shrink-0">
-                <GroupNutzapButton
-                  groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`}
-                  ownerPubkey={community.pubkey}
-                  className="w-auto"
-                />
-              </div>
-            )}
+          <div className="max-w-3xl mx-auto">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-semibold">Group eCash</h2>
+              {user && community && (
+                <div className="flex-shrink-0">
+                  <GroupNutzapButton
+                    groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`}
+                    ownerPubkey={community.pubkey}
+                    className="w-auto"
+                  />
+                </div>
+              )}
+            </div>
+            <GroupNutzapList groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`} />
           </div>
-          <GroupNutzapList groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`} />
         </TabsContent>
 
         <TabsContent value="members" className="space-y-4">


### PR DESCRIPTION
This PR improves the eCash tab in the group detail page with a more compact design and ensures consistent width across all tabs.

## Changes

### 1. Consistent Width
- Wrapped eCash tab content in `max-w-3xl mx-auto` container to match the width of the group header and posts tab

### 2. Compact Design for eCash Entries
- Reduced padding from `CardHeader` + `CardContent` to just `CardContent` with `p-3`
- Decreased spacing between cards from `space-y-4` to `space-y-2`
- Made avatars smaller (from `h-10 w-10` to `h-9 w-9`)
- Removed unnecessary card header separation

### 3. Improved Visual Appeal
- Added hover effect (`hover:bg-accent/50`) for better interactivity
- Changed link hover from underline to opacity for modern feel
- Made amounts more prominent with `font-semibold`
- Added `line-clamp-2` to limit message content to 2 lines
- Improved truncation for long usernames

### 4. Enhanced Empty State
- Added Zap icon and more engaging copy when no eCash is present
- Better visual hierarchy with icon and descriptive text

### 5. Updated Loading State
- Made skeleton loaders match the new compact design
- Consistent spacing and sizing with actual content

## Result
The eCash tab now has a cleaner, more compact appearance that's consistent with the rest of the UI, reducing visual clutter while maintaining readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the layout and visual hierarchy of loading, empty, and list item states in the Nutzap list, including refined spacing, reduced avatar and text sizes, and enhanced card hover effects.
  - Enhanced the empty state with a centered icon and updated text styling.
  - Consolidated the "ecash" tab content into a centered container for a more cohesive appearance.
- **Refactor**
  - Simplified component structures by removing redundant headers and improving flex layouts for better responsiveness and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->