### PR TITLE
Link to njump on share post

### DIFF
--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -651,15 +651,34 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
   };
 
   const handleSharePost = async () => {
-    // For now, share the group URL with a hash to the post
-    // In the future, we could add a dedicated post view
-    const shareUrl = `${window.location.origin}/group/${encodeURIComponent(communityId)}#${post.id}`;
-    
-    await shareContent({
-      title: "Check out this post",
-      text: post.content.slice(0, 100) + (post.content.length > 100 ? "..." : ""),
-      url: shareUrl
-    });
+    try {
+      // Create nevent identifier for the post with relay hint
+      const nevent = nip19.neventEncode({
+        id: post.id,
+        author: post.pubkey,
+        kind: post.kind,
+        relays: ["wss://relay.chorus.community"],
+      });
+      
+      // Create njump.me URL
+      const shareUrl = `https://njump.me/${nevent}`;
+      
+      await shareContent({
+        title: "Check out this post",
+        text: post.content.slice(0, 100) + (post.content.length > 100 ? "..." : ""),
+        url: shareUrl
+      });
+    } catch (error) {
+      console.error("Error creating share URL:", error);
+      // Fallback to the original URL format
+      const shareUrl = `${window.location.origin}/group/${encodeURIComponent(communityId)}#${post.id}`;
+      
+      await shareContent({
+        title: "Check out this post",
+        text: post.content.slice(0, 100) + (post.content.length > 100 ? "..." : ""),
+        url: shareUrl
+      });
+    }
   };
 
   const handlePinPost = async () => {


### PR DESCRIPTION
This works, see for example: https://njump.me/nevent1qvzqqqqqpvpzpyexz3t34l966ngh5xg7u2q788hthdqmj0av3lv8s2tz9t43zt6dqyw8wumn8ghj7un9d3shjtnrdphhyatn9e3k7mtdw4hxjareqqsdvrc3kqs7dmj3y27fjzzk9udjjce65rpzgthrqjx8datz770tthq5l7tc9

However njump doesnt currently support Kind 11. 

Alex is trying to vibe it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced sharing functionality for posts and replies, now generating shareable links using Nostr event identifiers and the njump.me service for improved interoperability.
- **Bug Fixes**
  - Improved error handling during the share process, ensuring a fallback link is always provided if an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->