### PR TITLE
Show eCash button and currency switcher for all users

### DIFF
--- a/src/components/groups/GroupNutzapTotal.tsx
+++ b/src/components/groups/GroupNutzapTotal.tsx
@@ -34,10 +34,7 @@ export function GroupNutzapTotal({ groupId, className = "" }: GroupNutzapTotalPr
     return <Skeleton className={`h-6 w-24 ${className}`} />;
   }
 
-  if (total === 0) {
-    return null; // Don't show anything if there are no nutzaps
-  }
-
+  // Always show even when total is 0, displaying "0 sats" or "$0.00"
   return (
     <button
       type="button"

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -505,36 +505,27 @@ export default function GroupDetail() {
           </div>
 
           <div className="flex flex-col min-w-[140px] h-40 space-y-2">
-            {!isModerator ? (
-              <>
-                <div className="h-8">
-                  <JoinRequestButton communityId={groupId || ''} isModerator={isModerator || false} />
-                </div>
-                {/* If there are more buttons than these, they will flow from top to bottom */}
-                {/* Ensure consistent height for GroupNutzapTotal */}
-                <div className="h-8 flex items-center">
-                  <GroupNutzapTotal groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`} />
-                </div>
-              </>
-            ) : (
-              <>
-                {/* Ensure consistent height for GroupNutzapButton */}
-                <div className="h-8">
-                  {user && community && (
-                    <GroupNutzapButton
-                      groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`}
-                      ownerPubkey={community.pubkey}
-                      variant="outline"
-                      className="w-full h-full"
-                    />
-                  )}
-                </div>
-                {/* Ensure consistent height for GroupNutzapTotal */}
-                <div className="h-8 flex items-center">
-                  <GroupNutzapTotal groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`} />
-                </div>
-              </>
-            )}
+            <div className="h-8">
+              <JoinRequestButton communityId={groupId || ''} isModerator={isModerator || false} />
+            </div>
+            {/* Ensure consistent height for GroupNutzapButton */}
+            <div className="h-8">
+              {user && community && (
+                <GroupNutzapButton
+                  groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`}
+                  ownerPubkey={community.pubkey}
+                  variant="outline"
+                  className="w-full h-full"
+                />
+              )}
+            </div>
+            {/* Ensure consistent height for GroupNutzapTotal - always show for all users */}
+            <div className="h-8 flex items-center">
+              <GroupNutzapTotal 
+                groupId={`34550:${parsedId?.pubkey}:${parsedId?.identifier}`}
+                className="w-full"
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
This PR adds the Send eCash button and currency switcher for all users, regardless of membership status in a group. 

Changes:
- Modified GroupDetail.tsx to show Send eCash button for all users
- Modified GroupNutzapTotal.tsx to display even when total is 0 (showing '0 sats' or 'bash.00')
- Made currency switcher visible next to group image, accessible to all users

These changes ensure that both the Send eCash button and the currency switcher are accessible to all users, improving the experience for non-members who want to contribute to a group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The total sats or dollar amount is now always displayed, even when the value is zero.
  - All users now consistently see the Join Request, Nutzap, and Nutzap Total buttons in group detail views, regardless of moderator status.

- **Style**
  - Improved layout consistency for the displayed buttons in group detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->