### PR TITLE
TBD: Group Censorship? 

### DIFF
--- a/HIDE_GROUPS_FEATURE.md
+++ b/HIDE_GROUPS_FEATURE.md
@@ -1,0 +1,123 @@
+# Hide Groups Feature
+
+This document describes the implementation of the Hide Groups feature for Site Admins.
+
+## Overview
+
+Site Admins can now hide groups from all public listings using 1984 (report) events. Hidden groups will not appear in:
+- The main Groups page
+- Profile pages' common groups sections
+- Any other public group listings
+
+## Site Admin Definition
+
+Site Admins are defined as owners or moderators of this specific group:
+`34550:932614571afcbad4d17a191ee281e39eebbb41b93fac8fd87829622aeb112f4d:and-other-stuff-mb3c9stb`
+
+## How It Works
+
+### For Site Admins
+
+1. **Hide a Group**: Site Admins see a "Hide group" option in the dropdown menu (three dots) on any group card
+2. **Report Dialog**: Clicking "Hide group" opens a dialog similar to the post reporting dialog
+3. **Reason Selection**: Site Admins can select from predefined reasons:
+   - Spam
+   - Illegal content
+   - Malware/Scam
+   - Inappropriate
+   - Other
+4. **Additional Details**: Site Admins can provide additional context in a text area
+5. **Submit**: The system creates a 1984 (report) event that tags the group ID
+
+### For All Users
+
+1. **Hidden Groups**: Groups with 1984 events from Site Admins are automatically filtered out of all public listings
+2. **Real-time Updates**: The hidden groups list is cached and refreshed periodically
+3. **No Notification**: Regular users don't see any indication that groups have been hidden
+
+## Technical Implementation
+
+### New Hooks
+
+- `useSiteAdmin()`: Checks if the current user is a Site Admin
+- `useHiddenGroups()`: Fetches and caches the list of hidden groups
+- `useHideGroup()`: Allows Site Admins to hide groups
+
+### New Components
+
+- `HideGroupDialog`: Dialog for Site Admins to hide groups with reason selection
+
+### Updated Components
+
+- `GroupCard`: Added "Hide group" option for Site Admins
+- `Groups`: Filters out hidden groups
+- `CommonGroupsList`: Filters out hidden groups
+- `CommonGroupsListImproved`: Filters out hidden groups
+
+### Event Structure
+
+When a Site Admin hides a group, a 1984 event is created with:
+- `kind`: 1984 (REPORT)
+- `tags`: `[["a", communityId, reason]]`
+- `content`: Additional details provided by the Site Admin
+
+### Filtering Logic
+
+The system:
+1. Queries for all 1984 events from Site Admin pubkeys
+2. Extracts group IDs from "a" tags that start with "34550:"
+3. Filters these groups from all public listings
+4. Caches the results for performance
+
+## Files Modified
+
+### New Files
+- `src/hooks/useSiteAdmin.ts`
+- `src/hooks/useHiddenGroups.ts`
+- `src/hooks/useHideGroup.ts`
+- `src/components/groups/HideGroupDialog.tsx`
+
+### Modified Files
+- `src/components/groups/GroupCard.tsx`
+- `src/pages/Groups.tsx`
+- `src/components/profile/CommonGroupsList.tsx`
+- `src/components/profile/CommonGroupsListImproved.tsx`
+
+## Usage
+
+### For Site Admins
+1. Navigate to any group listing
+2. Click the three dots menu on a group card
+3. Select "Hide group"
+4. Choose a reason and provide details
+5. Click "Hide Group"
+
+### For Developers
+```typescript
+// Check if user is Site Admin
+const { isSiteAdmin } = useSiteAdmin();
+
+// Get hidden groups
+const { data: hiddenGroups } = useHiddenGroups();
+
+// Hide a group (Site Admins only)
+const { hideGroup } = useHideGroup();
+await hideGroup({
+  communityId: "34550:pubkey:identifier",
+  reason: "spam",
+  details: "This group is posting spam content"
+});
+```
+
+## Security Considerations
+
+- Only Site Admins can hide groups
+- The Site Admin group ID is hardcoded to prevent unauthorized access
+- Hidden groups are filtered client-side based on 1984 events
+- The system relies on the integrity of the Nostr network for event verification
+
+## Performance
+
+- Hidden groups list is cached with 1-minute stale time
+- Queries are optimized with timeouts and limits
+- Filtering is done in memory for fast performance

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -22,6 +22,8 @@ const CashuWallet = lazy(() => import("./pages/CashuWallet"));
 const LinkPreviewTest = lazy(() => import("./pages/LinkPreviewTest"));
 const AboutPage = lazy(() => import("@/pages/AboutPage"));
 const FaqPage = lazy(() => import("@/pages/FaqPage"));
+const HiddenGroups = lazy(() => import("@/pages/HiddenGroups"));
+const HiddenGroupsTest = lazy(() => import("@/pages/HiddenGroupsTest"));
 
 // Loading component
 function PageLoader() {
@@ -97,6 +99,16 @@ export function AppRouter() {
         <Route path="/faq" element={
           <Suspense fallback={<PageLoader />}>
             <FaqPage />
+          </Suspense>
+        } />
+        <Route path="/admin/hidden-groups" element={
+          <Suspense fallback={<PageLoader />}>
+            <HiddenGroups />
+          </Suspense>
+        } />
+        <Route path="/admin/hidden-groups-test" element={
+          <Suspense fallback={<PageLoader />}>
+            <HiddenGroupsTest />
           </Suspense>
         } />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -14,6 +14,7 @@ import {
   Wallet,
   Info,
   Download,
+  EyeOff,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -34,6 +35,7 @@ import { useCashuStore } from "@/stores/cashuStore";
 import { useState } from "react";
 import { PWAInstallInstructions } from "@/components/PWAInstallInstructions";
 import { usePWA } from "@/hooks/usePWA";
+import { useSiteAdmin } from "@/hooks/useSiteAdmin";
 interface AccountSwitcherProps {
   onAddAccountClick: () => void;
 }
@@ -47,6 +49,7 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
   const cashuStore = useCashuStore();
   const [showInstallInstructions, setShowInstallInstructions] = useState(false);
   const { isInstallable, isRunningAsPwa, promptInstall } = usePWA();
+  const { isSiteAdmin } = useSiteAdmin();
 
   const handleInstallClick = async () => {
     if (isInstallable) {
@@ -161,6 +164,17 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
               <span>Settings</span>
             </a>
           </DropdownMenuItem>
+          {isSiteAdmin && (
+            <DropdownMenuItem
+              asChild
+              className="flex items-center gap-2 cursor-pointer p-1.5 rounded-md text-sm md:gap-2 gap-3"
+            >
+              <a href="/admin/hidden-groups">
+                <EyeOff className="w-3.5 h-3.5 md:w-3.5 md:h-3.5 w-4 h-4" />
+                <span>Hidden Groups</span>
+              </a>
+            </DropdownMenuItem>
+          )}
           <DropdownMenuSeparator className="my-1" />
 
           <DropdownMenuItem

--- a/src/components/groups/GroupCard.tsx
+++ b/src/components/groups/GroupCard.tsx
@@ -285,14 +285,15 @@ export function GroupCard({
           </DropdownMenu>
         )}
 
-        {/* Hide Group Dialog */}
-        <HideGroupDialog
-          isOpen={showHideDialog}
-          onClose={() => setShowHideDialog(false)}
-          communityId={communityId}
-          groupName={name}
-        />
       </Card>
+
+      {/* Hide Group Dialog - Outside Link to prevent navigation conflicts */}
+      <HideGroupDialog
+        isOpen={showHideDialog}
+        onClose={() => setShowHideDialog(false)}
+        communityId={communityId}
+        groupName={name}
+      />
     </Link>
   );
 }

--- a/src/components/groups/GroupCard.tsx
+++ b/src/components/groups/GroupCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Pin, PinOff, MessageSquare, Activity, MoreVertical, UserPlus, AlertTriangle, Clock } from "lucide-react";
+import { Pin, PinOff, MessageSquare, Activity, MoreVertical, UserPlus, AlertTriangle, Clock, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { RoleBadge } from "@/components/groups/RoleBadge";
@@ -12,15 +12,19 @@ import type { UserRole } from "@/hooks/useUserRole";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useOpenReportsCount } from "@/hooks/useOpenReportsCount";
 import { usePendingJoinRequests } from "@/hooks/usePendingJoinRequests";
+import { useSiteAdmin } from "@/hooks/useSiteAdmin";
 import { toast } from "sonner";
 import type { NostrEvent } from "@nostrify/nostrify";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { JoinRequestMenuItem } from "@/components/groups/JoinRequestMenuItem";
+import { HideGroupDialog } from "@/components/groups/HideGroupDialog";
+import { useState } from "react";
 
 interface GroupCardProps {
   community: NostrEvent;
@@ -51,6 +55,8 @@ export function GroupCard({
   isLoadingStats,
 }: GroupCardProps) {
   const { user } = useCurrentUser();
+  const { isSiteAdmin } = useSiteAdmin();
+  const [showHideDialog, setShowHideDialog] = useState(false);
 
   // Extract community data from tags
   const nameTag = community.tags.find((tag) => tag[0] === "name");
@@ -88,6 +94,12 @@ export function GroupCard({
     } else {
       pinGroup(communityId);
     }
+  };
+
+  const handleHideGroup = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setShowHideDialog(true);
   };
 
   // Get the first letter of the group name for avatar fallback
@@ -260,9 +272,26 @@ export function GroupCard({
                 </DropdownMenuItem>
               )}
               {!isUserMember && <JoinRequestMenuItem communityId={communityId} hasPendingRequest={hasPendingRequest} />}
+              {isSiteAdmin && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleHideGroup} className="text-red-600 focus:text-red-600">
+                    <EyeOff className="h-4 w-4 mr-2" />
+                    Hide group
+                  </DropdownMenuItem>
+                </>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}
+
+        {/* Hide Group Dialog */}
+        <HideGroupDialog
+          isOpen={showHideDialog}
+          onClose={() => setShowHideDialog(false)}
+          communityId={communityId}
+          groupName={name}
+        />
       </Card>
     </Link>
   );

--- a/src/components/groups/HideGroupDialog.tsx
+++ b/src/components/groups/HideGroupDialog.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import { useHideGroup, HideGroupReason } from "@/hooks/useHideGroup";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { EyeOff } from "lucide-react";
+
+interface HideGroupDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  communityId: string;
+  groupName?: string;
+}
+
+export function HideGroupDialog({
+  isOpen,
+  onClose,
+  communityId,
+  groupName,
+}: HideGroupDialogProps) {
+  const { user } = useCurrentUser();
+  const { hideGroup, isPending } = useHideGroup();
+  const [reason, setReason] = useState<HideGroupReason>("other");
+  const [details, setDetails] = useState("");
+
+  const handleSubmit = async () => {
+    if (!user) return;
+
+    try {
+      await hideGroup({
+        communityId,
+        reason,
+        details,
+      });
+      
+      // Reset form and close dialog
+      setReason("other");
+      setDetails("");
+      onClose();
+    } catch (error) {
+      // Error is handled in the hook
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <EyeOff className="h-5 w-5 text-red-500" />
+            Hide Group
+          </DialogTitle>
+          <DialogDescription>
+            Hide this group from all public listings. This action will prevent the group from appearing in any group lists across the platform.
+          </DialogDescription>
+        </DialogHeader>
+
+        {groupName && (
+          <div className="bg-muted p-3 rounded-md text-sm mb-4">
+            <p className="font-medium text-xs mb-1 text-muted-foreground">Group being hidden:</p>
+            <p className="font-medium">{groupName}</p>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="hide-reason">Reason for hiding</Label>
+            <RadioGroup
+              id="hide-reason"
+              value={reason}
+              onValueChange={(value) => setReason(value as HideGroupReason)}
+              className="grid grid-cols-2 gap-2"
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="spam" id="spam" />
+                <Label htmlFor="spam">Spam</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="illegal" id="illegal" />
+                <Label htmlFor="illegal">Illegal content</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="malware" id="malware" />
+                <Label htmlFor="malware">Malware/Scam</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="inappropriate" id="inappropriate" />
+                <Label htmlFor="inappropriate">Inappropriate</Label>
+              </div>
+              <div className="flex items-center space-x-2 col-span-2">
+                <RadioGroupItem value="other" id="other" />
+                <Label htmlFor="other">Other</Label>
+              </div>
+            </RadioGroup>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="hide-details">Additional details</Label>
+            <Textarea
+              id="hide-details"
+              placeholder="Please provide more information about why you're hiding this group..."
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+              rows={4}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button 
+            onClick={handleSubmit} 
+            disabled={isPending || !user}
+            variant="destructive"
+          >
+            {isPending ? "Hiding..." : "Hide Group"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/groups/HideGroupDialog.tsx
+++ b/src/components/groups/HideGroupDialog.tsx
@@ -54,7 +54,7 @@ export function HideGroupDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[500px]" onClick={(e) => e.stopPropagation()}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <EyeOff className="h-5 w-5 text-red-500" />
@@ -80,6 +80,7 @@ export function HideGroupDialog({
               value={reason}
               onValueChange={(value) => setReason(value as HideGroupReason)}
               className="grid grid-cols-2 gap-2"
+              onClick={(e) => e.stopPropagation()}
             >
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="spam" id="spam" />
@@ -111,17 +112,22 @@ export function HideGroupDialog({
               placeholder="Please provide more information about why you're hiding this group..."
               value={details}
               onChange={(e) => setDetails(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
               rows={4}
             />
           </div>
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={isPending}>
+          <Button 
+            variant="outline" 
+            onClick={(e) => { e.stopPropagation(); onClose(); }} 
+            disabled={isPending}
+          >
             Cancel
           </Button>
           <Button 
-            onClick={handleSubmit} 
+            onClick={(e) => { e.stopPropagation(); handleSubmit(); }} 
             disabled={isPending || !user}
             variant="destructive"
           >

--- a/src/components/profile/CommonGroupsList.tsx
+++ b/src/components/profile/CommonGroupsList.tsx
@@ -1,5 +1,6 @@
 import { useNostr } from "@/hooks/useNostr";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useHiddenGroups } from "@/hooks/useHiddenGroups";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/card";
@@ -136,6 +137,7 @@ function RoleBadge({
 export function CommonGroupsList({ profileUserPubkey }: CommonGroupsListProps) {
   const { nostr } = useNostr();
   const { user } = useCurrentUser();
+  const { data: hiddenGroups = new Set() } = useHiddenGroups();
 
   const { data: commonGroups, isLoading } = useQuery({
     queryKey: ["common-groups", user?.pubkey, profileUserPubkey],
@@ -228,8 +230,10 @@ export function CommonGroupsList({ profileUserPubkey }: CommonGroupsListProps) {
       for (const event of communityEvents) {
         const communityId = getCommunityId(event);
         
-        // Only include if both users are actually members
-        if (currentUserCommunityIds.has(communityId) && profileUserCommunityIds.has(communityId)) {
+        // Only include if both users are actually members and group is not hidden
+        if (currentUserCommunityIds.has(communityId) && 
+            profileUserCommunityIds.has(communityId) && 
+            !hiddenGroups.has(communityId)) {
           const nameTag = event.tags.find(tag => tag[0] === "name");
           const descriptionTag = event.tags.find(tag => tag[0] === "description");
           const imageTag = event.tags.find(tag => tag[0] === "image");

--- a/src/components/profile/CommonGroupsListImproved.tsx
+++ b/src/components/profile/CommonGroupsListImproved.tsx
@@ -1,5 +1,6 @@
 import { useNostr } from "@/hooks/useNostr";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useHiddenGroups } from "@/hooks/useHiddenGroups";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/card";
@@ -144,6 +145,7 @@ function UserWithRole({
 export function CommonGroupsListImproved({ profileUserPubkey }: CommonGroupsListProps) {
   const { nostr } = useNostr();
   const { user } = useCurrentUser();
+  const { data: hiddenGroups = new Set() } = useHiddenGroups();
   const profileAuthor = useAuthor(profileUserPubkey);
   const profileMetadata = profileAuthor.data?.metadata;
   const profileDisplayName = profileMetadata?.name || profileUserPubkey.slice(0, 8);
@@ -239,8 +241,10 @@ export function CommonGroupsListImproved({ profileUserPubkey }: CommonGroupsList
       for (const event of communityEvents) {
         const communityId = getCommunityId(event);
         
-        // Only include if both users are actually members
-        if (currentUserCommunityIds.has(communityId) && profileUserCommunityIds.has(communityId)) {
+        // Only include if both users are actually members and group is not hidden
+        if (currentUserCommunityIds.has(communityId) && 
+            profileUserCommunityIds.has(communityId) && 
+            !hiddenGroups.has(communityId)) {
           const nameTag = event.tags.find(tag => tag[0] === "name");
           const descriptionTag = event.tags.find(tag => tag[0] === "description");
           const imageTag = event.tags.find(tag => tag[0] === "image");

--- a/src/hooks/useHiddenGroups.ts
+++ b/src/hooks/useHiddenGroups.ts
@@ -1,0 +1,84 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNostr } from "./useNostr";
+import { KINDS } from "@/lib/nostr-kinds";
+
+// The specific Site Admin group ID
+const SITE_ADMIN_GROUP_ID = "34550:932614571afcbad4d17a191ee281e39eebbb41b93fac8fd87829622aeb112f4d:and-other-stuff-mb3c9stb";
+
+/**
+ * Hook to get the list of hidden groups based on 1984 events from Site Admins
+ */
+export function useHiddenGroups() {
+  const { nostr } = useNostr();
+
+  return useQuery({
+    queryKey: ["hidden-groups"],
+    queryFn: async (c) => {
+      try {
+        const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+        
+        // First, get the Site Admin group to find its owners and moderators
+        const siteAdminGroups = await nostr.query(
+          [{ 
+            kinds: [KINDS.GROUP], 
+            "#d": ["and-other-stuff-mb3c9stb"],
+            authors: ["932614571afcbad4d17a191ee281e39eebbb41b93fac8fd87829622aeb112f4d"]
+          }],
+          { signal }
+        );
+
+        if (!siteAdminGroups || siteAdminGroups.length === 0) {
+          return new Set<string>();
+        }
+
+        const siteAdminGroup = siteAdminGroups[0];
+        
+        // Extract site admin pubkeys (owner + moderators)
+        const siteAdminPubkeys = new Set<string>();
+        
+        // Add the owner (group creator)
+        siteAdminPubkeys.add(siteAdminGroup.pubkey);
+        
+        // Add moderators
+        for (const tag of siteAdminGroup.tags) {
+          if (tag[0] === "p" && tag[3] === "moderator") {
+            siteAdminPubkeys.add(tag[1]);
+          }
+        }
+
+        if (siteAdminPubkeys.size === 0) {
+          return new Set<string>();
+        }
+
+        // Now get all 1984 events from Site Admins
+        const reportEvents = await nostr.query(
+          [{ 
+            kinds: [KINDS.REPORT],
+            authors: Array.from(siteAdminPubkeys),
+            limit: 1000
+          }],
+          { signal }
+        );
+
+        // Extract hidden group IDs from the reports
+        const hiddenGroupIds = new Set<string>();
+        
+        for (const event of reportEvents) {
+          // Look for "a" tags that reference groups (kind 34550)
+          for (const tag of event.tags) {
+            if (tag[0] === "a" && tag[1] && tag[1].startsWith("34550:")) {
+              hiddenGroupIds.add(tag[1]);
+            }
+          }
+        }
+
+        return hiddenGroupIds;
+      } catch (error) {
+        console.error("Error fetching hidden groups:", error);
+        return new Set<string>();
+      }
+    },
+    staleTime: 60000, // 1 minute
+    gcTime: 300000, // 5 minutes
+  });
+}

--- a/src/hooks/useHideGroup.ts
+++ b/src/hooks/useHideGroup.ts
@@ -1,0 +1,66 @@
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useSiteAdmin } from "@/hooks/useSiteAdmin";
+import { KINDS } from "@/lib/nostr-kinds";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+
+export type HideGroupReason = "spam" | "illegal" | "malware" | "inappropriate" | "other";
+
+export interface HideGroupOptions {
+  communityId: string;
+  reason: HideGroupReason;
+  details: string;
+}
+
+/**
+ * Hook for Site Admins to hide groups using 1984 events
+ */
+export function useHideGroup() {
+  const { mutateAsync: publishEvent, isPending } = useNostrPublish();
+  const { user } = useCurrentUser();
+  const { isSiteAdmin } = useSiteAdmin();
+  const queryClient = useQueryClient();
+
+  const hideGroup = async (options: HideGroupOptions) => {
+    if (!user) {
+      toast.error("You must be logged in to hide groups");
+      throw new Error("User not logged in");
+    }
+
+    if (!isSiteAdmin) {
+      toast.error("You must be a Site Admin to hide groups");
+      throw new Error("User is not a Site Admin");
+    }
+
+    const { communityId, reason, details } = options;
+
+    const tags: string[][] = [
+      ["a", communityId, reason]
+    ];
+
+    try {
+      await publishEvent({
+        kind: KINDS.REPORT,
+        tags,
+        content: details || "",
+      });
+
+      // Invalidate hidden groups query to refresh the list
+      queryClient.invalidateQueries({ queryKey: ["hidden-groups"] });
+
+      toast.success("Group hidden successfully");
+      return true;
+    } catch (error) {
+      console.error("Error hiding group:", error);
+      toast.error("Failed to hide group. Please try again.");
+      throw error;
+    }
+  };
+
+  return {
+    hideGroup,
+    isPending,
+    canHideGroups: isSiteAdmin
+  };
+}

--- a/src/hooks/useSiteAdmin.ts
+++ b/src/hooks/useSiteAdmin.ts
@@ -1,0 +1,20 @@
+import { useUserRole } from "./useUserRole";
+
+// The specific Site Admin group ID
+const SITE_ADMIN_GROUP_ID = "34550:932614571afcbad4d17a191ee281e39eebbb41b93fac8fd87829622aeb112f4d:and-other-stuff-mb3c9stb";
+
+/**
+ * Hook to check if the current user is a Site Admin
+ * Site Admins are owners or moderators of the specific Site Admin group
+ */
+export function useSiteAdmin() {
+  const { data: userRole, isLoading } = useUserRole(SITE_ADMIN_GROUP_ID);
+  
+  const isSiteAdmin = userRole === "owner" || userRole === "moderator";
+  
+  return {
+    isSiteAdmin,
+    isLoading,
+    userRole
+  };
+}

--- a/src/pages/HiddenGroups.tsx
+++ b/src/pages/HiddenGroups.tsx
@@ -1,0 +1,309 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { useSiteAdmin } from "@/hooks/useSiteAdmin";
+import { useHiddenGroups } from "@/hooks/useHiddenGroups";
+import Header from "@/components/ui/Header";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { RichText } from "@/components/ui/RichText";
+import { EyeOff, AlertTriangle, MessageSquare, Activity, Eye } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Link, Navigate } from "react-router-dom";
+import { useState } from "react";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { KINDS } from "@/lib/nostr-kinds";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+import type { NostrEvent } from "@nostrify/nostrify";
+
+// Helper function to get community ID
+const getCommunityId = (community: NostrEvent) => {
+  const dTag = community.tags.find((tag) => tag[0] === "d");
+  return `${KINDS.GROUP}:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+};
+
+interface HiddenGroupCardProps {
+  community: NostrEvent;
+  onUnhide: (communityId: string) => void;
+  isUnhiding: boolean;
+}
+
+function HiddenGroupCard({ community, onUnhide, isUnhiding }: HiddenGroupCardProps) {
+  // Extract community data from tags
+  const nameTag = community.tags.find((tag) => tag[0] === "name");
+  const descriptionTag = community.tags.find((tag) => tag[0] === "description");
+  const imageTag = community.tags.find((tag) => tag[0] === "image");
+  const dTag = community.tags.find((tag) => tag[0] === "d");
+
+  const name = nameTag ? nameTag[1] : dTag ? dTag[1] : "Unnamed Group";
+  const description = descriptionTag ? descriptionTag[1] : "No description available";
+  const image = imageTag ? imageTag[1] : undefined;
+  const communityId = getCommunityId(community);
+
+  // Get the first letter of the group name for avatar fallback
+  const getInitials = () => {
+    return name.charAt(0).toUpperCase();
+  };
+
+  const handleUnhide = () => {
+    onUnhide(communityId);
+  };
+
+  return (
+    <Card className="overflow-hidden flex flex-col relative group h-full">
+      <div className="absolute top-2 right-2 z-10">
+        <Badge variant="destructive" className="text-xs">
+          <EyeOff className="h-3 w-3 mr-1" />
+          Hidden
+        </Badge>
+      </div>
+
+      <CardHeader className="flex flex-row items-center space-y-0 gap-3 pt-4 pb-2 px-3">
+        <div className="flex items-center gap-3">
+          <Avatar className="h-12 w-12 rounded-md">
+            <AvatarImage src={image} alt={name} />
+            <AvatarFallback className="bg-primary/10 text-primary font-medium">
+              {getInitials()}
+            </AvatarFallback>
+          </Avatar>
+          <div className="space-y-1 flex-1">
+            <CardTitle className="text-sm font-medium leading-tight">{name}</CardTitle>
+            <div className="text-xs text-muted-foreground">
+              ID: {communityId.split(":")[2] || "Unknown"}
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="px-3 pb-3 pt-0 flex-1 flex flex-col">
+        <RichText className="line-clamp-3 text-xs mb-4 flex-1">
+          {description}
+        </RichText>
+        
+        <div className="flex gap-2">
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="flex-1"
+          >
+            <Link to={`/group/${encodeURIComponent(communityId)}`}>
+              <Eye className="h-3 w-3 mr-1" />
+              View Group
+            </Link>
+          </Button>
+          <Button
+            onClick={handleUnhide}
+            disabled={isUnhiding}
+            size="sm"
+            className="flex-1"
+          >
+            {isUnhiding ? "Unhiding..." : "Unhide"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function HiddenGroups() {
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+  const { isSiteAdmin, isLoading: isSiteAdminLoading } = useSiteAdmin();
+  const { data: hiddenGroupIds = new Set(), isLoading: isHiddenGroupsLoading } = useHiddenGroups();
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const queryClient = useQueryClient();
+  const [unhidingGroups, setUnhidingGroups] = useState<Set<string>>(new Set());
+
+  // Fetch the actual group events for hidden groups
+  const { data: hiddenGroups = [], isLoading: isGroupsLoading } = useQuery({
+    queryKey: ["hidden-groups-details", Array.from(hiddenGroupIds)],
+    queryFn: async (c) => {
+      if (hiddenGroupIds.size === 0) return [];
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(8000)]);
+      
+      // Convert group IDs to filters
+      const filters = Array.from(hiddenGroupIds).map(groupId => {
+        const parts = groupId.split(":");
+        if (parts.length === 3) {
+          return {
+            kinds: [parseInt(parts[0])],
+            authors: [parts[1]],
+            "#d": [parts[2]],
+            limit: 1
+          };
+        }
+        return null;
+      }).filter((filter): filter is NonNullable<typeof filter> => filter !== null);
+
+      if (filters.length === 0) return [];
+
+      try {
+        const events = await nostr.query(filters, { signal });
+        return events;
+      } catch (error) {
+        console.error("Error fetching hidden group details:", error);
+        return [];
+      }
+    },
+    enabled: hiddenGroupIds.size > 0,
+    staleTime: 60000, // 1 minute
+  });
+
+  // Debug: Log the site admin status
+  console.log("Site Admin Debug:", { isSiteAdmin, isSiteAdminLoading, user: user?.pubkey });
+
+  // Show access denied for non-admins instead of redirecting
+  if (!isSiteAdminLoading && !isSiteAdmin) {
+    return (
+      <div className="container mx-auto py-1 px-3 sm:px-4">
+        <Header />
+        <div className="flex justify-center items-center min-h-[400px]">
+          <div className="text-center">
+            <EyeOff className="h-16 w-16 text-red-500 mx-auto mb-4" />
+            <h1 className="text-2xl font-bold mb-2">Access Denied</h1>
+            <p className="text-muted-foreground mb-4">
+              You must be a Site Admin to access this page.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Debug: isSiteAdmin={String(isSiteAdmin)}, userPubkey={user?.pubkey || 'none'}
+            </p>
+            <Button asChild className="mt-4">
+              <Link to="/">Go Home</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const handleUnhideGroup = async (communityId: string) => {
+    if (!user || !isSiteAdmin) {
+      toast.error("You must be a Site Admin to unhide groups");
+      return;
+    }
+
+    setUnhidingGroups(prev => new Set(prev).add(communityId));
+
+    try {
+      // Create a deletion event for the 1984 report
+      // We'll use a kind 5 deletion event that references the original report
+      await publishEvent({
+        kind: KINDS.DELETION,
+        tags: [
+          ["a", communityId, "unhidden by admin"]
+        ],
+        content: `Group unhidden by Site Admin: ${communityId}`,
+      });
+
+      // Invalidate queries to refresh the lists
+      queryClient.invalidateQueries({ queryKey: ["hidden-groups"] });
+      queryClient.invalidateQueries({ queryKey: ["hidden-groups-details"] });
+
+      toast.success("Group unhidden successfully");
+    } catch (error) {
+      console.error("Error unhiding group:", error);
+      toast.error("Failed to unhide group. Please try again.");
+    } finally {
+      setUnhidingGroups(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(communityId);
+        return newSet;
+      });
+    }
+  };
+
+  if (isSiteAdminLoading) {
+    return (
+      <div className="container mx-auto py-1 px-3 sm:px-4">
+        <Header />
+        <div className="flex justify-center items-center min-h-[200px]">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+            <p className="text-muted-foreground">Checking permissions...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-1 px-3 sm:px-4">
+      <Header />
+
+      <div className="flex flex-col mt-4">
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-2">
+            <EyeOff className="h-6 w-6 text-red-500" />
+            <h1 className="text-2xl font-bold">Hidden Groups</h1>
+            <Badge variant="secondary" className="text-xs">
+              Site Admin Only
+            </Badge>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            Groups that have been hidden from public listings. Only Site Admins can view and manage hidden groups.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {isHiddenGroupsLoading || isGroupsLoading ? (
+            <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <Card key={index} className="overflow-hidden flex flex-col h-[200px]">
+                  <CardHeader className="flex flex-row items-center space-y-0 gap-3 pt-4 pb-2 px-3">
+                    <Skeleton className="h-12 w-12 rounded-md" />
+                    <div className="space-y-1 flex-1">
+                      <Skeleton className="h-4 w-3/4" />
+                      <Skeleton className="h-3 w-1/2" />
+                    </div>
+                  </CardHeader>
+                  <CardContent className="px-3 pb-3 pt-0 flex-1">
+                    <Skeleton className="h-3 w-full mb-1" />
+                    <Skeleton className="h-3 w-2/3 mb-4" />
+                    <div className="flex gap-2 mt-auto">
+                      <Skeleton className="h-8 flex-1" />
+                      <Skeleton className="h-8 flex-1" />
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : hiddenGroups.length > 0 ? (
+            <>
+              <div className="flex items-center justify-between mb-4">
+                <p className="text-sm text-muted-foreground">
+                  Found {hiddenGroups.length} hidden {hiddenGroups.length === 1 ? 'group' : 'groups'}
+                </p>
+              </div>
+              <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3">
+                {hiddenGroups.map((community) => {
+                  const communityId = getCommunityId(community);
+                  return (
+                    <HiddenGroupCard
+                      key={communityId}
+                      community={community}
+                      onUnhide={handleUnhideGroup}
+                      isUnhiding={unhidingGroups.has(communityId)}
+                    />
+                  );
+                })}
+              </div>
+            </>
+          ) : (
+            <div className="text-center py-12">
+              <EyeOff className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h2 className="text-xl font-semibold mb-2">No Hidden Groups</h2>
+              <p className="text-muted-foreground">
+                There are currently no groups hidden from public listings.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/HiddenGroupsTest.tsx
+++ b/src/pages/HiddenGroupsTest.tsx
@@ -1,0 +1,230 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useHiddenGroups } from "@/hooks/useHiddenGroups";
+import Header from "@/components/ui/Header";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { RichText } from "@/components/ui/RichText";
+import { EyeOff, Eye } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
+import { KINDS } from "@/lib/nostr-kinds";
+import type { NostrEvent } from "@nostrify/nostrify";
+
+// Helper function to get community ID
+const getCommunityId = (community: NostrEvent) => {
+  const dTag = community.tags.find((tag) => tag[0] === "d");
+  return `${KINDS.GROUP}:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+};
+
+interface HiddenGroupCardProps {
+  community: NostrEvent;
+}
+
+function HiddenGroupCard({ community }: HiddenGroupCardProps) {
+  // Extract community data from tags
+  const nameTag = community.tags.find((tag) => tag[0] === "name");
+  const descriptionTag = community.tags.find((tag) => tag[0] === "description");
+  const imageTag = community.tags.find((tag) => tag[0] === "image");
+  const dTag = community.tags.find((tag) => tag[0] === "d");
+
+  const name = nameTag ? nameTag[1] : dTag ? dTag[1] : "Unnamed Group";
+  const description = descriptionTag ? descriptionTag[1] : "No description available";
+  const image = imageTag ? imageTag[1] : undefined;
+  const communityId = getCommunityId(community);
+
+  // Get the first letter of the group name for avatar fallback
+  const getInitials = () => {
+    return name.charAt(0).toUpperCase();
+  };
+
+  return (
+    <Card className="overflow-hidden flex flex-col relative group h-full">
+      <div className="absolute top-2 right-2 z-10">
+        <Badge variant="destructive" className="text-xs">
+          <EyeOff className="h-3 w-3 mr-1" />
+          Hidden
+        </Badge>
+      </div>
+
+      <CardHeader className="flex flex-row items-center space-y-0 gap-3 pt-4 pb-2 px-3">
+        <div className="flex items-center gap-3">
+          <Avatar className="h-12 w-12 rounded-md">
+            <AvatarImage src={image} alt={name} />
+            <AvatarFallback className="bg-primary/10 text-primary font-medium">
+              {getInitials()}
+            </AvatarFallback>
+          </Avatar>
+          <div className="space-y-1 flex-1">
+            <CardTitle className="text-sm font-medium leading-tight">{name}</CardTitle>
+            <div className="text-xs text-muted-foreground">
+              ID: {communityId.split(":")[2] || "Unknown"}
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="px-3 pb-3 pt-0 flex-1 flex flex-col">
+        <RichText className="line-clamp-3 text-xs mb-4 flex-1">
+          {description}
+        </RichText>
+        
+        <div className="flex gap-2">
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="flex-1"
+          >
+            <Link to={`/group/${encodeURIComponent(communityId)}`}>
+              <Eye className="h-3 w-3 mr-1" />
+              View Group
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function HiddenGroupsTest() {
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+  const { data: hiddenGroupIds = new Set(), isLoading: isHiddenGroupsLoading } = useHiddenGroups();
+
+  // Fetch the actual group events for hidden groups
+  const { data: hiddenGroups = [], isLoading: isGroupsLoading } = useQuery({
+    queryKey: ["hidden-groups-details", Array.from(hiddenGroupIds)],
+    queryFn: async (c) => {
+      if (hiddenGroupIds.size === 0) return [];
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(8000)]);
+      
+      // Convert group IDs to filters
+      const filters = Array.from(hiddenGroupIds).map(groupId => {
+        const parts = groupId.split(":");
+        if (parts.length === 3) {
+          return {
+            kinds: [parseInt(parts[0])],
+            authors: [parts[1]],
+            "#d": [parts[2]],
+            limit: 1
+          };
+        }
+        return null;
+      }).filter((filter): filter is NonNullable<typeof filter> => filter !== null);
+
+      if (filters.length === 0) return [];
+
+      try {
+        const events = await nostr.query(filters, { signal });
+        return events;
+      } catch (error) {
+        console.error("Error fetching hidden group details:", error);
+        return [];
+      }
+    },
+    enabled: hiddenGroupIds.size > 0,
+    staleTime: 60000, // 1 minute
+  });
+
+  if (!user) {
+    return (
+      <div className="container mx-auto py-1 px-3 sm:px-4">
+        <Header />
+        <div className="flex justify-center items-center min-h-[400px]">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold mb-2">Please Log In</h1>
+            <p className="text-muted-foreground">
+              You must be logged in to view this test page.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-1 px-3 sm:px-4">
+      <Header />
+
+      <div className="flex flex-col mt-4">
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-2">
+            <EyeOff className="h-6 w-6 text-red-500" />
+            <h1 className="text-2xl font-bold">Hidden Groups Test</h1>
+            <Badge variant="secondary" className="text-xs">
+              Test Version
+            </Badge>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            This is a test version that shows hidden groups to any logged-in user for debugging purposes.
+          </p>
+          <div className="mt-2 p-3 bg-muted rounded-lg text-sm">
+            <p><strong>Debug Info:</strong></p>
+            <p>User: {user.pubkey}</p>
+            <p>Hidden Group IDs: {Array.from(hiddenGroupIds).join(", ") || "None"}</p>
+            <p>Hidden Groups Loading: {String(isHiddenGroupsLoading)}</p>
+            <p>Groups Loading: {String(isGroupsLoading)}</p>
+            <p>Hidden Groups Count: {hiddenGroups.length}</p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {isHiddenGroupsLoading || isGroupsLoading ? (
+            <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <Card key={index} className="overflow-hidden flex flex-col h-[200px]">
+                  <CardHeader className="flex flex-row items-center space-y-0 gap-3 pt-4 pb-2 px-3">
+                    <Skeleton className="h-12 w-12 rounded-md" />
+                    <div className="space-y-1 flex-1">
+                      <Skeleton className="h-4 w-3/4" />
+                      <Skeleton className="h-3 w-1/2" />
+                    </div>
+                  </CardHeader>
+                  <CardContent className="px-3 pb-3 pt-0 flex-1">
+                    <Skeleton className="h-3 w-full mb-1" />
+                    <Skeleton className="h-3 w-2/3 mb-4" />
+                    <div className="flex gap-2 mt-auto">
+                      <Skeleton className="h-8 flex-1" />
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : hiddenGroups.length > 0 ? (
+            <>
+              <div className="flex items-center justify-between mb-4">
+                <p className="text-sm text-muted-foreground">
+                  Found {hiddenGroups.length} hidden {hiddenGroups.length === 1 ? 'group' : 'groups'}
+                </p>
+              </div>
+              <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3">
+                {hiddenGroups.map((community) => {
+                  const communityId = getCommunityId(community);
+                  return (
+                    <HiddenGroupCard
+                      key={communityId}
+                      community={community}
+                    />
+                  );
+                })}
+              </div>
+            </>
+          ) : (
+            <div className="text-center py-12">
+              <EyeOff className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h2 className="text-xl font-semibold mb-2">No Hidden Groups</h2>
+              <p className="text-muted-foreground">
+                There are currently no groups hidden from public listings.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds the ability for AOS team to hide groups from the main feed. I don't actually think we need this right now, but its here in case we need to act quickly on something later.  I think it works. Submits a 1984 event to hide a group, and a delete request of that report to unhide. 

![Screenshot from 2025-05-26 16-40-18](https://github.com/user-attachments/assets/76d4dbf9-14f1-4b11-9620-51902fdd8315)

![Screenshot from 2025-05-26 16-40-42](https://github.com/user-attachments/assets/8fbcc28f-d9c0-4d3d-b001-fe617994b084)

![Screenshot from 2025-05-26 16-42-48](https://github.com/user-attachments/assets/87f56cd9-f888-4212-be90-6264c1374706)

![Screenshot from 2025-05-26 17-05-23](https://github.com/user-attachments/assets/bb3798f6-f78f-48e4-b71c-24faf4cfcb87)
