### PR TITLE
sort groups on list by members

### DIFF
--- a/src/pages/Groups.tsx
+++ b/src/pages/Groups.tsx
@@ -199,7 +199,19 @@ export default function Groups() {
           return aPriority - bPriority;
         }
 
-        // If same priority, sort alphabetically by name
+        // If same priority, sort by member count (descending), then alphabetically by name
+        const aStats = communityStats ? communityStats[aId] : undefined;
+        const bStats = communityStats ? communityStats[bId] : undefined;
+        
+        const aMemberCount = aStats ? aStats.participants.size : 0;
+        const bMemberCount = bStats ? bStats.participants.size : 0;
+        
+        // Sort by member count (descending)
+        if (aMemberCount !== bMemberCount) {
+          return bMemberCount - aMemberCount;
+        }
+        
+        // If same member count, sort alphabetically by name
         const aNameTag = a.tags.find((tag) => tag[0] === "name");
         const bNameTag = b.tags.find((tag) => tag[0] === "name");
 
@@ -218,6 +230,7 @@ export default function Groups() {
     isGroupPinned,
     userMembershipMap,
     pendingJoinRequestsSet,
+    communityStats,
   ]);
 
   // Loading state skeleton with stable keys


### PR DESCRIPTION
Sorts groups (beneath pins and groups you're a part of) by most members. I think this is a better option for now than #380 

![Screenshot from 2025-05-26 17-12-09](https://github.com/user-attachments/assets/934ab6b9-c62c-4825-a912-61aac98890ae)
