### PR TITLE
Ability for Group Owners to Delete Groups

### DIFF
--- a/src/components/groups/DeletedGroupBadge.tsx
+++ b/src/components/groups/DeletedGroupBadge.tsx
@@ -1,0 +1,43 @@
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface DeletedGroupBadgeProps {
+  deletionDate?: Date;
+  reason?: string;
+  className?: string;
+}
+
+export function DeletedGroupBadge({ deletionDate, reason, className }: DeletedGroupBadgeProps) {
+  const tooltipContent = (
+    <div className="space-y-1">
+      <div className="font-medium">Group Deleted</div>
+      {deletionDate && (
+        <div className="text-xs">
+          Deleted on {deletionDate.toLocaleDateString()}
+        </div>
+      )}
+      {reason && (
+        <div className="text-xs">
+          <strong>Reason:</strong> {reason}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge variant="destructive" className={className}>
+            <AlertTriangle className="h-3 w-3 mr-1" />
+            Deleted
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>
+          {tooltipContent}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/profile/CommonGroupsListImproved.tsx
+++ b/src/components/profile/CommonGroupsListImproved.tsx
@@ -13,6 +13,7 @@ import { useAuthor } from "@/hooks/useAuthor";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 import { KINDS } from "@/lib/nostr-kinds";
+import { useGroupDeletionRequests } from "@/hooks/useGroupDeletionRequests";
 
 interface CommonGroup {
   id: string;
@@ -263,6 +264,17 @@ export function CommonGroupsListImproved({ profileUserPubkey }: CommonGroupsList
     enabled: !!nostr && !!user && !!profileUserPubkey && user.pubkey !== profileUserPubkey,
   });
 
+  // Get group IDs for deletion checking
+  const groupIds = commonGroups?.map(group => group.id) || [];
+  const { data: deletionRequests } = useGroupDeletionRequests(groupIds);
+
+  // Filter out deleted groups
+  const filteredCommonGroups = commonGroups?.filter(group => {
+    if (!deletionRequests) return true;
+    const deletionRequest = deletionRequests.get(group.id);
+    return !(deletionRequest?.isValid || false);
+  }) || [];
+
   // Don't show anything if viewing own profile
   if (!user || !profileUserPubkey || user.pubkey === profileUserPubkey) {
     return null;
@@ -292,7 +304,7 @@ export function CommonGroupsListImproved({ profileUserPubkey }: CommonGroupsList
     );
   }
 
-  if (!commonGroups || commonGroups.length === 0) {
+  if (!filteredCommonGroups || filteredCommonGroups.length === 0) {
     return null; // Don't show section if no common groups
   }
 
@@ -304,12 +316,12 @@ export function CommonGroupsListImproved({ profileUserPubkey }: CommonGroupsList
           <h3 className="text-lg font-semibold">Shared Groups</h3>
         </div>
         <Badge variant="secondary" className="text-xs font-medium">
-          {commonGroups.length} {commonGroups.length === 1 ? 'group' : 'groups'}
+          {filteredCommonGroups.length} {filteredCommonGroups.length === 1 ? 'group' : 'groups'}
         </Badge>
       </div>
       
       <div className="space-y-3">
-        {commonGroups.map((group) => (
+        {filteredCommonGroups.map((group) => (
           <Link
             key={group.id}
             to={`/group/${encodeURIComponent(group.id)}`}

--- a/src/hooks/useFilterDeletedGroups.ts
+++ b/src/hooks/useFilterDeletedGroups.ts
@@ -1,0 +1,41 @@
+import { useMemo } from "react";
+import { useGroupDeletionRequests } from "./useGroupDeletionRequests";
+import type { NostrEvent } from "@nostrify/nostrify";
+import { KINDS } from "@/lib/nostr-kinds";
+
+// Helper function to get a unique community ID
+function getCommunityId(community: NostrEvent): string {
+  const dTag = community.tags.find(tag => tag[0] === "d");
+  return `${KINDS.GROUP}:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+}
+
+/**
+ * Hook to filter out deleted groups from a list of groups
+ * @param groups Array of group events to filter
+ * @returns Filtered array with deleted groups removed
+ */
+export function useFilterDeletedGroups(groups: NostrEvent[] | undefined) {
+  // Get group IDs for deletion checking
+  const groupIds = useMemo(() => {
+    if (!groups) return [];
+    return groups.map(getCommunityId);
+  }, [groups]);
+
+  // Check for deletion requests
+  const { data: deletionRequests } = useGroupDeletionRequests(groupIds);
+
+  // Filter out deleted groups
+  const filteredGroups = useMemo(() => {
+    if (!groups || !deletionRequests) {
+      return groups;
+    }
+
+    return groups.filter(group => {
+      const groupId = getCommunityId(group);
+      const deletionRequest = deletionRequests.get(groupId);
+      return !(deletionRequest?.isValid || false);
+    });
+  }, [groups, deletionRequests]);
+
+  return filteredGroups;
+}

--- a/src/hooks/useGroupDeletionRequests.ts
+++ b/src/hooks/useGroupDeletionRequests.ts
@@ -27,12 +27,47 @@ export function useGroupDeletionRequests(groupIds: string[]) {
       try {
         const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
         
-        // Query for kind 5 deletion events that reference groups via 'a' tags
-        const deletionEvents = await nostr.query([{
-          kinds: [KINDS.DELETION],
-          "#a": groupIds,
-          limit: 1000 // Should be enough for deletion requests
-        }], { signal });
+        // Query for kind 5 deletion events that reference groups via 'a' tags or 'e' tags
+        // We need to extract event IDs from group IDs for 'e' tag filtering
+        const groupEventIds: string[] = [];
+        
+        // For each group ID, we need to query for the actual group event to get its event ID
+        // This is needed for 'e' tag compatibility
+        for (const groupId of groupIds) {
+          const parts = groupId.split(":");
+          if (parts.length === 3 && parts[0] === KINDS.GROUP.toString()) {
+            const [, pubkey, identifier] = parts;
+            try {
+              const groupEvents = await nostr.query([{
+                kinds: [KINDS.GROUP],
+                authors: [pubkey],
+                "#d": [identifier],
+                limit: 1
+              }], { signal: AbortSignal.timeout(2000) });
+              
+              if (groupEvents.length > 0) {
+                groupEventIds.push(groupEvents[0].id);
+              }
+            } catch (error) {
+              // If we can't fetch the group event, skip it for 'e' tag filtering
+              console.warn("Could not fetch group event for deletion filtering:", groupId, error);
+            }
+          }
+        }
+
+        // Query for deletion events using both 'a' tags and 'e' tags
+        const deletionEvents = await nostr.query([
+          {
+            kinds: [KINDS.DELETION],
+            "#a": groupIds,
+            limit: 500
+          },
+          ...(groupEventIds.length > 0 ? [{
+            kinds: [KINDS.DELETION],
+            "#e": groupEventIds,
+            limit: 500
+          }] : [])
+        ], { signal });
 
         const deletionMap = new Map<string, GroupDeletionRequest>();
 
@@ -43,6 +78,7 @@ export function useGroupDeletionRequests(groupIds: string[]) {
             tag[0] === "a" && tag[1] && tag[1].startsWith(`${KINDS.GROUP}:`)
           );
 
+          // Process 'a' tags (addressable event references)
           for (const aTag of aTags) {
             const groupId = aTag[1];
             
@@ -66,6 +102,57 @@ export function useGroupDeletionRequests(groupIds: string[]) {
                 isValid,
                 reason: deletionEvent.content || undefined
               });
+            }
+          }
+
+          // Also check 'e' tags for event ID references
+          // This provides compatibility with relays that primarily use 'e' tags for deletions
+          const eTags = deletionEvent.tags.filter(tag => tag[0] === "e" && tag[1]);
+          
+          if (eTags.length > 0) {
+            // For 'e' tag processing, we need to be more careful since we need to match
+            // event IDs to group IDs. We'll query for the referenced events to validate them.
+            for (const eTag of eTags) {
+              const eventId = eTag[1];
+              
+              try {
+                // Query for the referenced event to see if it's a group event
+                const referencedEvents = await nostr.query([{
+                  ids: [eventId],
+                  kinds: [KINDS.GROUP],
+                  limit: 1
+                }], { signal: AbortSignal.timeout(2000) });
+                
+                if (referencedEvents.length > 0) {
+                  const groupEvent = referencedEvents[0];
+                  const dTag = groupEvent.tags.find(tag => tag[0] === "d");
+                  
+                  if (dTag) {
+                    const groupId = `${KINDS.GROUP}:${groupEvent.pubkey}:${dTag[1]}`;
+                    
+                    // Check if this group is in our target list
+                    if (groupIds.includes(groupId)) {
+                      // Validate that the deletion request is from the group owner
+                      const isValid = deletionEvent.pubkey === groupEvent.pubkey;
+                      
+                      // Only store the most recent valid deletion request for each group
+                      const existing = deletionMap.get(groupId);
+                      if (!existing || (isValid && deletionEvent.created_at > existing.deletionEvent.created_at)) {
+                        deletionMap.set(groupId, {
+                          deletionEvent,
+                          groupId,
+                          isValid,
+                          reason: deletionEvent.content || undefined
+                        });
+                      }
+                    }
+                  }
+                }
+              } catch (error) {
+                // If we can't fetch the referenced event, skip this 'e' tag
+                console.warn("Could not fetch referenced event for deletion validation:", eventId, error);
+                continue;
+              }
             }
           }
         }

--- a/src/hooks/useGroupDeletionRequests.ts
+++ b/src/hooks/useGroupDeletionRequests.ts
@@ -1,0 +1,108 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNostr } from "@/hooks/useNostr";
+import { KINDS } from "@/lib/nostr-kinds";
+import type { NostrEvent } from "@nostrify/nostrify";
+
+interface GroupDeletionRequest {
+  deletionEvent: NostrEvent;
+  groupId: string;
+  isValid: boolean;
+  reason?: string;
+}
+
+/**
+ * Hook to fetch and validate deletion requests for groups
+ * Returns a map of groupId -> deletion request info
+ */
+export function useGroupDeletionRequests(groupIds: string[]) {
+  const { nostr } = useNostr();
+
+  return useQuery({
+    queryKey: ["group-deletion-requests", groupIds.sort()],
+    queryFn: async (c) => {
+      if (groupIds.length === 0) {
+        return new Map<string, GroupDeletionRequest>();
+      }
+
+      try {
+        const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+        
+        // Query for kind 5 deletion events that reference groups via 'a' tags
+        const deletionEvents = await nostr.query([{
+          kinds: [KINDS.DELETION],
+          "#a": groupIds,
+          limit: 1000 // Should be enough for deletion requests
+        }], { signal });
+
+        const deletionMap = new Map<string, GroupDeletionRequest>();
+
+        // Process each deletion event
+        for (const deletionEvent of deletionEvents) {
+          // Find the 'a' tags that reference groups (kind 34550)
+          const aTags = deletionEvent.tags.filter(tag => 
+            tag[0] === "a" && tag[1] && tag[1].startsWith(`${KINDS.GROUP}:`)
+          );
+
+          for (const aTag of aTags) {
+            const groupId = aTag[1];
+            
+            // Parse the group ID to get the owner's pubkey
+            const parts = groupId.split(":");
+            if (parts.length !== 3 || parts[0] !== KINDS.GROUP.toString()) {
+              continue;
+            }
+            
+            const [, groupOwnerPubkey] = parts;
+            
+            // Validate that the deletion request is from the group owner
+            const isValid = deletionEvent.pubkey === groupOwnerPubkey;
+            
+            // Only store the most recent valid deletion request for each group
+            const existing = deletionMap.get(groupId);
+            if (!existing || (isValid && deletionEvent.created_at > existing.deletionEvent.created_at)) {
+              deletionMap.set(groupId, {
+                deletionEvent,
+                groupId,
+                isValid,
+                reason: deletionEvent.content || undefined
+              });
+            }
+          }
+        }
+
+        return deletionMap;
+      } catch (error) {
+        console.error("Error fetching group deletion requests:", error);
+        return new Map<string, GroupDeletionRequest>();
+      }
+    },
+    enabled: groupIds.length > 0,
+    staleTime: 30000, // 30 seconds
+    gcTime: 300000, // 5 minutes
+  });
+}
+
+/**
+ * Hook to check if a specific group has been deleted
+ */
+export function useIsGroupDeleted(groupId: string | undefined) {
+  const { data: deletionRequests } = useGroupDeletionRequests(
+    groupId ? [groupId] : []
+  );
+
+  if (!groupId || !deletionRequests) {
+    return {
+      isDeleted: false,
+      deletionRequest: undefined,
+      isLoading: false
+    };
+  }
+
+  const deletionRequest = deletionRequests.get(groupId);
+  
+  return {
+    isDeleted: deletionRequest?.isValid || false,
+    deletionRequest: deletionRequest?.isValid ? deletionRequest : undefined,
+    isLoading: false
+  };
+}

--- a/src/hooks/useNostrPublish.ts
+++ b/src/hooks/useNostrPublish.ts
@@ -201,6 +201,24 @@ export function useNostrPublish(options?: UseNostrPublishOptions) {
             break;
           }
           
+          case KINDS.DELETION: {
+            // Find groups being deleted via 'a' tags
+            const groupATags = event.tags.filter(tag => 
+              tag[0] === "a" && tag[1] && tag[1].startsWith(`${KINDS.GROUP}:`)
+            );
+            
+            if (groupATags.length > 0) {
+              const groupIds = groupATags.map(tag => tag[1]);
+              // Invalidate deletion request queries
+              queryClient.invalidateQueries({ queryKey: ["group-deletion-requests"] });
+              // Invalidate communities list to remove deleted groups
+              queryClient.invalidateQueries({ queryKey: ["communities"] });
+              // Invalidate user groups
+              queryClient.invalidateQueries({ queryKey: ["user-groups"] });
+            }
+            break;
+          }
+          
           case CASHU_EVENT_KINDS.ZAP: {
             // Find the event being zapped
             const zappedEventId = event.tags.find(tag => tag[0] === "e")?.[1];

--- a/src/hooks/useUserGroups.ts
+++ b/src/hooks/useUserGroups.ts
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { NostrEvent, NostrFilter } from "@nostrify/nostrify";
 import { usePinnedGroups } from "./usePinnedGroups";
 import { KINDS } from "@/lib/nostr-kinds";
+import { useGroupDeletionRequests } from "./useGroupDeletionRequests";
 
 // Helper function to get a unique community ID
 function getCommunityId(community: NostrEvent): string {

--- a/src/hooks/useUserGroupsFiltered.ts
+++ b/src/hooks/useUserGroupsFiltered.ts
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import { useUserGroups } from "./useUserGroups";
+import { useGroupDeletionRequests } from "./useGroupDeletionRequests";
+import type { NostrEvent } from "@nostrify/nostrify";
+import { KINDS } from "@/lib/nostr-kinds";
+
+// Helper function to get a unique community ID
+function getCommunityId(community: NostrEvent): string {
+  const dTag = community.tags.find(tag => tag[0] === "d");
+  return `${KINDS.GROUP}:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+}
+
+/**
+ * Hook that returns user's groups filtered to exclude deleted groups
+ */
+export function useUserGroupsFiltered() {
+  const userGroupsQuery = useUserGroups();
+  
+  // Get group IDs for deletion checking
+  const groupIds = useMemo(() => {
+    if (!userGroupsQuery.data?.allGroups) return [];
+    return userGroupsQuery.data.allGroups.map(getCommunityId);
+  }, [userGroupsQuery.data?.allGroups]);
+
+  // Check for deletion requests
+  const { data: deletionRequests } = useGroupDeletionRequests(groupIds);
+
+  // Filter out deleted groups
+  const filteredData = useMemo(() => {
+    if (!userGroupsQuery.data || !deletionRequests) {
+      return userGroupsQuery.data;
+    }
+
+    const isGroupDeleted = (community: NostrEvent) => {
+      const groupId = getCommunityId(community);
+      const deletionRequest = deletionRequests.get(groupId);
+      return deletionRequest?.isValid || false;
+    };
+
+    const filterGroups = (groups: NostrEvent[]) => 
+      groups.filter(group => !isGroupDeleted(group));
+
+    return {
+      pinned: filterGroups(userGroupsQuery.data.pinned),
+      owned: filterGroups(userGroupsQuery.data.owned),
+      moderated: filterGroups(userGroupsQuery.data.moderated),
+      member: filterGroups(userGroupsQuery.data.member),
+      allGroups: filterGroups(userGroupsQuery.data.allGroups)
+    };
+  }, [userGroupsQuery.data, deletionRequests]);
+
+  return {
+    ...userGroupsQuery,
+    data: filteredData
+  };
+}

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -45,6 +45,9 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { useGroup } from "@/hooks/useGroup";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
 import { useNavigate } from "react-router-dom";
+import { useIsGroupDeleted } from "@/hooks/useGroupDeletionRequests";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
 
 export default function GroupDetail() {
   const { groupId } = useParams<{ groupId: string }>();
@@ -83,6 +86,11 @@ export default function GroupDetail() {
   }, [groupId]);
 
   const { data: community, isLoading: isLoadingCommunity } = useGroup(groupId);
+
+  // Check if group has been deleted
+  const { isDeleted: isGroupDeleted, deletionRequest } = useIsGroupDeleted(
+    parsedId ? `${KINDS.GROUP}:${parsedId.pubkey}:${parsedId.identifier}` : undefined
+  );
 
   // Get approved members using the centralized hook
   const { approvedMembers } = useApprovedMembers(groupId || '');
@@ -494,11 +502,44 @@ export default function GroupDetail() {
   if (!community) {
     return (
       <div className="container mx-auto py-1 px-3 sm:px-4">
+        <Header />
         <h1 className="text-2xl font-bold mb-4">Group not found</h1>
         <p>The group you're looking for doesn't exist or has been deleted.</p>
         <Button asChild className="mt-2">
           <Link to="/groups">Back to Groups</Link>
         </Button>
+      </div>
+    );
+  }
+
+  // Show deletion notice if group has been deleted
+  if (isGroupDeleted && deletionRequest) {
+    return (
+      <div className="container mx-auto py-1 px-3 sm:px-4">
+        <Header />
+        
+        <div className="max-w-3xl mx-auto mt-8">
+          <Alert className="border-destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription className="space-y-2">
+              <div className="font-semibold">This group has been deleted</div>
+              <p>
+                The group owner has requested deletion of this group on{" "}
+                {new Date(deletionRequest.deletionEvent.created_at * 1000).toLocaleDateString()}.
+              </p>
+              {deletionRequest.reason && (
+                <p className="text-sm text-muted-foreground">
+                  <strong>Reason:</strong> {deletionRequest.reason}
+                </p>
+              )}
+              <div className="pt-2">
+                <Button asChild>
+                  <Link to="/groups">Browse Other Groups</Link>
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        </div>
       </div>
     );
   }

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -387,10 +387,12 @@ export default function GroupDetail() {
 
     try {
       // Create a kind 5 deletion event referencing the group
+      // Include both 'a' tag (addressable event) and 'e' tag (event ID) for maximum relay compatibility
       await publishEvent({
         kind: KINDS.DELETION,
         tags: [
           ["a", `${KINDS.GROUP}:${community.pubkey}:${parsedId.identifier}`],
+          ["e", community.id],
           ["k", KINDS.GROUP.toString()]
         ],
         content: "Requesting deletion of this group",

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -869,7 +869,7 @@ export default function GroupDetail() {
                                       <li>Make the group inaccessible to new users</li>
                                     </ul>
                                     <p className="text-sm font-medium text-destructive">
-                                      Note: This is a request for deletion. Individual relays may choose whether to honor this request.
+                                      Note: This is a request for deletion. Individual relays may choose whether to honor this request. This does not delete individual posts within the group.
                                     </p>
                                   </AlertDialogDescription>
                                 </AlertDialogHeader>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { QRCodeModal } from "@/components/QRCodeModal";
 import { CommonGroupsListImproved } from "@/components/profile/CommonGroupsListImproved";
+import { useIsGroupDeleted } from "@/hooks/useGroupDeletionRequests";
 
 // Hook to get shared group IDs
 function useSharedGroupIds(profileUserPubkey: string): string[] {
@@ -184,6 +185,7 @@ function extractGroupInfo(post: NostrEvent): { groupId: string; groupName: strin
 // Component to fetch and display group name
 function GroupNameDisplay({ groupId }: { groupId: string }) {
   const { nostr } = useNostr();
+  const { isDeleted } = useIsGroupDeleted(groupId);
 
   const { data: groupName, isLoading } = useQuery({
     queryKey: ["group-name", groupId],
@@ -226,14 +228,32 @@ function GroupNameDisplay({ groupId }: { groupId: string }) {
     return <span>Loading...</span>;
   }
 
+  // Show "Deleted" if the group has been deleted
+  if (isDeleted) {
+    return <span className="font-medium text-muted-foreground">Deleted</span>;
+  }
+
   return <span className="font-medium">{groupName || "Group"}</span>;
 }
 
 // Component to display group information on a post
 function PostGroupLink({ post }: { post: NostrEvent }) {
   const groupInfo = extractGroupInfo(post);
+  const { isDeleted } = useIsGroupDeleted(groupInfo?.groupId);
 
   if (!groupInfo) return null;
+
+  // If the group is deleted, show a non-clickable version
+  if (isDeleted) {
+    return (
+      <div className="flex items-center text-xs md:text-sm text-muted-foreground">
+        <div className="flex items-center px-2 py-1 rounded-full bg-muted/70">
+          <Users className="h-3 w-3 md:h-4 md:w-4 mr-1.5" />
+          <GroupNameDisplay groupId={groupInfo.groupId} />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <Link


### PR DESCRIPTION
- Submits kind 5s with a and e tags to the group
- Hides the deleted groups in the UI even if the relay didn't delete them
- Checks to ensure the delete request came from the owner of the group
- Maintains posts from deleted groups, but indicates the original group was deleted
- Warns users that this does not guarantee deletion and does not delete posts within the group

I think this will help with the "junk" spam of people just creating groups for testing or multiple groups on accident. They can delete their own group to clean it up if its junk. 

![Screenshot from 2025-05-27 07-20-12](https://github.com/user-attachments/assets/ea1c1295-aaa9-4dc6-82fd-6f0773539eca)


![Screenshot from 2025-05-27 07-38-18](https://github.com/user-attachments/assets/686036d9-663e-4240-acab-acc5fe427b60)


![Screenshot from 2025-05-27 08-02-46](https://github.com/user-attachments/assets/15b04f49-4c01-497e-b8ac-26965648e8ae)


![Screenshot from 2025-05-27 07-38-45](https://github.com/user-attachments/assets/6710f135-3166-4287-a8b0-a15ea86068b9)
