### PR TITLE
Add repost feature (Issue #47)

### DIFF
--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -89,11 +89,11 @@ function RepostCount({ postId }: { postId: string }) {
     queryFn: async (c) => {
       const signal = AbortSignal.any([c.signal, AbortSignal.timeout(3000)]);
 
-      // Get all kind 1101 posts (group posts) that reference this post with a "k" "repost" tag
+      // Get all group posts that reference this post with a "k" tag
       const events = await nostr.query([{
         kinds: [KINDS.GROUP_POST],
         "#e": [postId],
-        "#k": ["repost"],
+        "#k": [String(KINDS.REPOST)],
         limit: 100,
       }], { signal });
 
@@ -759,7 +759,7 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
                     </Tooltip>
                   </TooltipProvider>
                 )}
-                {post.tags.find(tag => tag[0] === "k" && tag[1] === "repost") && (
+                {post.tags.find(tag => tag[0] === "k" && tag[1] === String(KINDS.REPOST)) && (
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -12,7 +12,7 @@ import { useBannedUsers } from "@/hooks/useBannedUsers";
 import { usePinnedPosts } from "@/hooks/usePinnedPosts";
 import { useApprovedMembers } from "@/hooks/useApprovedMembers";
 import { toast } from "sonner";
-import { MessageSquare, Share2, CheckCircle, XCircle, MoreVertical, Ban, ChevronDown, ChevronUp, Flag, Timer, Pin } from "lucide-react";
+import { MessageSquare, Share2, CheckCircle, XCircle, MoreVertical, Ban, ChevronDown, ChevronUp, Flag, Timer, Pin, Repeat } from "lucide-react";
 import { EmojiReactionButton } from "@/components/EmojiReactionButton";
 import { NutzapButton } from "@/components/groups/NutzapButton";
 import { NutzapInterface } from "@/components/groups/NutzapInterface";
@@ -24,6 +24,7 @@ import { parseNostrAddress } from "@/lib/nostr-utils";
 import { formatRelativeTime } from "@/lib/utils";
 import { ReplyList } from "./ReplyList";
 import { ReportDialog } from "./ReportDialog";
+import { RepostDialog } from "./RepostDialog";
 import { shareContent } from "@/lib/share";
 import { KINDS } from "@/lib/nostr-kinds";
 import {
@@ -77,6 +78,35 @@ function ReplyCount({ postId }: { postId: string }) {
   }
 
   return <span className="text-xs ml-0.5">{replyCount}</span>;
+}
+
+// Repost Count Component
+function RepostCount({ postId }: { postId: string }) {
+  const { nostr } = useNostr();
+
+  const { data: repostCount } = useQuery({
+    queryKey: ["repost-count", postId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(3000)]);
+
+      // Get all kind 1101 posts (group posts) that reference this post with a "k" "repost" tag
+      const events = await nostr.query([{
+        kinds: [KINDS.GROUP_POST],
+        "#e": [postId],
+        "#k": ["repost"],
+        limit: 100,
+      }], { signal });
+
+      return events?.length || 0;
+    },
+    enabled: !!nostr && !!postId,
+  });
+
+  if (!repostCount || repostCount === 0) {
+    return null;
+  }
+
+  return <span className="text-xs ml-0.5">{repostCount}</span>;
 }
 
 interface PostListProps {
@@ -510,6 +540,7 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
   const [showReplies, setShowReplies] = useState(false);
   const [showZaps, setShowZaps] = useState(false);
   const [isReportDialogOpen, setIsReportDialogOpen] = useState(false);
+  const [isRepostDialogOpen, setIsRepostDialogOpen] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState<string | null>(null);
 
   // Handle toggle between replies and zaps
@@ -728,6 +759,21 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
                     </Tooltip>
                   </TooltipProvider>
                 )}
+                {post.tags.find(tag => tag[0] === "k" && tag[1] === "repost") && (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="flex items-center">
+                          <Repeat className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+                          <span className="text-xs text-muted-foreground ml-1">Repost</span>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Reposted from another group</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
               </div>
               <div className="flex items-center text-xs text-muted-foreground mt-0 flex-row">
                 <span
@@ -804,6 +850,11 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
                     <DropdownMenuItem onClick={handleSharePost} className="text-xs">
                       <Share2 className="h-3.5 w-3.5 mr-1.5 md:h-3.5 md:w-3.5 h-4 w-4" /> Share Post
                     </DropdownMenuItem>
+                    {user && (
+                      <DropdownMenuItem onClick={() => setIsRepostDialogOpen(true)} className="text-xs">
+                        <Repeat className="h-3.5 w-3.5 mr-1.5 md:h-3.5 md:w-3.5 h-4 w-4" /> Repost to Another Group
+                      </DropdownMenuItem>
+                    )}
                     {user && user.pubkey !== post.pubkey && (
                       <DropdownMenuItem onClick={() => setIsReportDialogOpen(true)} className="text-xs">
                         <Flag className="h-3.5 w-3.5 mr-1.5 md:h-3.5 md:w-3.5 h-4 w-4" /> Report Post
@@ -892,6 +943,11 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
                     <DropdownMenuItem onClick={handleSharePost} className="text-xs">
                       <Share2 className="h-3.5 w-3.5 mr-1.5 md:h-3.5 md:w-3.5 h-4 w-4" /> Share Post
                     </DropdownMenuItem>
+                    {user && (
+                      <DropdownMenuItem onClick={() => setIsRepostDialogOpen(true)} className="text-xs">
+                        <Repeat className="h-3.5 w-3.5 mr-1.5 md:h-3.5 md:w-3.5 h-4 w-4" /> Repost to Another Group
+                      </DropdownMenuItem>
+                    )}
                     {user && user.pubkey !== post.pubkey && (
                       <DropdownMenuItem onClick={() => setIsReportDialogOpen(true)} className="text-xs">
                         <Flag className="h-3.5 w-3.5 mr-1.5 md:h-3.5 md:w-3.5 h-4 w-4" /> Report Post
@@ -926,6 +982,23 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
               <ReplyCount postId={post.id} />
             </Button>
             <EmojiReactionButton postId={post.id} showText={false} />
+            {user ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground hover:text-foreground flex items-center h-7 px-1.5"
+                onClick={() => setIsRepostDialogOpen(true)}
+                title="Repost to Another Group"
+              >
+                <Repeat className={`h-3.5 w-3.5`} />
+                <RepostCount postId={post.id} />
+              </Button>
+            ) : (
+              <div className="text-muted-foreground flex items-center h-7 px-1.5">
+                <Repeat className={`h-3.5 w-3.5`} />
+                <RepostCount postId={post.id} />
+              </div>
+            )}
             <NutzapButton 
               postId={post.id} 
               authorPubkey={post.pubkey} 
@@ -985,6 +1058,14 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
         eventId={post.id}
         communityId={communityId}
         contentPreview={post.content}
+      />
+
+      {/* Repost Dialog */}
+      <RepostDialog
+        isOpen={isRepostDialogOpen}
+        onClose={() => setIsRepostDialogOpen(false)}
+        post={post}
+        sourceCommunityId={communityId}
       />
     </div>
   );

--- a/src/components/groups/RepostDialog.tsx
+++ b/src/components/groups/RepostDialog.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect } from "react";
+import { useUserGroupsFiltered } from "@/hooks/useUserGroupsFiltered";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { NostrEvent } from "@nostrify/nostrify";
+import { KINDS } from "@/lib/nostr-kinds";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+// Helper function to get community ID
+const getCommunityId = (community: NostrEvent) => {
+  const dTag = community.tags.find((tag) => tag[0] === "d");
+  return `${KINDS.GROUP}:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+};
+
+interface RepostDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  post: NostrEvent & {
+    approval?: {
+      id: string;
+      pubkey: string;
+      created_at: number;
+      autoApproved?: boolean;
+      kind: number;
+    };
+  };
+  sourceCommunityId: string;
+}
+
+export function RepostDialog({ isOpen, onClose, post, sourceCommunityId }: RepostDialogProps) {
+  const [selectedGroupId, setSelectedGroupId] = useState<string>("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  
+  const { data: userGroups, isLoading: isGroupsLoading } = useUserGroupsFiltered();
+  const { mutateAsync: publishEvent } = useNostrPublish({
+    invalidateQueries: [
+      { queryKey: ["pending-posts"] },
+      { queryKey: ["approved-posts"] }
+    ]
+  });
+
+  // Reset selected group when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedGroupId("");
+    }
+  }, [isOpen]);
+
+  // Filter out the source group to prevent reposting to the same group
+  const availableGroups = userGroups?.allGroups.filter(group => {
+    const groupId = getCommunityId(group);
+    return groupId !== sourceCommunityId;
+  }) || [];
+
+  const handleRepost = async () => {
+    if (!selectedGroupId) {
+      toast.error("Please select a group to repost to");
+      return;
+    }
+
+    setIsSubmitting(true);
+    
+    try {
+      // Create a new post with the same content but for the selected group
+      const repostEvent = {
+        kind: KINDS.GROUP_POST,
+        content: post.content,
+        tags: [
+          // Add selected group as the target
+          ["a", selectedGroupId],
+          // Add reference to the original post
+          ["e", post.id, "", "mention"],
+          // Add reference to the original author
+          ["p", post.pubkey],
+          // Add reference to the original source group
+          ["r", sourceCommunityId],
+          // Add repost tag to clearly mark this as a repost
+          ["k", "repost"]
+        ]
+      };
+      
+      // Add any media tags from the original post
+      post.tags
+        .filter(tag => tag[0] === "media" || tag[0] === "imeta" || tag[0] === "image")
+        .forEach(tag => {
+          repostEvent.tags.push(tag);
+        });
+      
+      // Add any hashtags from the original post
+      post.tags
+        .filter(tag => tag[0] === "t")
+        .forEach(tag => {
+          repostEvent.tags.push(tag);
+        });
+
+      await publishEvent(repostEvent);
+      
+      toast.success("Post has been reposted to the selected group");
+      onClose();
+    } catch (error) {
+      console.error("Error reposting:", error);
+      toast.error("Failed to repost. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Repost to Another Group</DialogTitle>
+          <DialogDescription>
+            Share this post to another group you belong to.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="group-select" className="text-sm font-medium">
+                Select Group
+              </label>
+              
+              {isGroupsLoading ? (
+                <div className="h-10 w-full animate-pulse bg-muted rounded-md"></div>
+              ) : availableGroups.length === 0 ? (
+                <div className="text-muted-foreground text-sm p-2 border rounded-md">
+                  You don't belong to any other groups. Join more groups to repost content.
+                </div>
+              ) : (
+                <Select
+                  value={selectedGroupId}
+                  onValueChange={setSelectedGroupId}
+                  disabled={isSubmitting}
+                >
+                  <SelectTrigger className="w-full" id="group-select">
+                    <SelectValue placeholder="Select a group" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>Your Groups</SelectLabel>
+                      {availableGroups.map((group) => {
+                        const groupId = getCommunityId(group);
+                        const nameTag = group.tags.find((tag) => tag[0] === "name");
+                        const name = nameTag ? nameTag[1] : "Unnamed Group";
+                        
+                        return (
+                          <SelectItem key={groupId} value={groupId}>
+                            {name}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              )}
+              
+              <p className="text-xs text-muted-foreground mt-1">
+                The post will appear as a new post in the selected group with reference to the original.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button 
+            onClick={handleRepost} 
+            disabled={!selectedGroupId || isSubmitting || availableGroups.length === 0}
+          >
+            {isSubmitting ? "Reposting..." : "Repost"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/groups/RepostDialog.tsx
+++ b/src/components/groups/RepostDialog.tsx
@@ -81,7 +81,7 @@ export function RepostDialog({ isOpen, onClose, post, sourceCommunityId }: Repos
     try {
       // Create a new post with the same content but for the selected group
       const repostEvent = {
-        kind: KINDS.GROUP_POST,
+        kind: KINDS.REPOST,
         content: post.content,
         tags: [
           // Add selected group as the target
@@ -93,7 +93,7 @@ export function RepostDialog({ isOpen, onClose, post, sourceCommunityId }: Repos
           // Add reference to the original source group
           ["r", sourceCommunityId],
           // Add repost tag to clearly mark this as a repost
-          ["k", "repost"]
+          ["k", String(post.kind)],
         ]
       };
       

--- a/src/lib/nostr-kinds.ts
+++ b/src/lib/nostr-kinds.ts
@@ -3,6 +3,7 @@ export const KINDS = {
   TEXT_NOTE: 1,
   FOLLOW_LIST: 3,
   DELETION: 5,
+  REPOST: 6,
   REACTION: 7,
   ZAP: 9735,
   REPORT: 1984,


### PR DESCRIPTION
This update introduces the ability for users to repost content from one group to any other group they belong to (Issue #47). The feature appears as a "Repost to another group" option on individual posts and allows cross-group sharing while preserving the original content and attribution.

Includes:
- New UI action on posts for reposting
- Group selection modal for eligible destination groups
- Backend support for creating reposted events in selected groups
- This feature improves group-to-group knowledge flow and encourages broader visibility of relevant conversations.

