### PR TITLE
Don't embed removed posts

### DIFF
--- a/NIP.md
+++ b/NIP.md
@@ -152,6 +152,9 @@ Moderator approval events for posts as specified in NIP-72.
 - `["p", authorPubkey]` - References the post author
 - `["k", originalKind]` - Kind of the original post
 
+**Content:**
+The content field can be left blank or optionally include a moderation reason.
+
 **Example:**
 ```json
 {
@@ -164,7 +167,7 @@ Moderator approval events for posts as specified in NIP-72.
     ["p", "post_author_pubkey"],
     ["k", "1"]
   ],
-  "content": "{\"kind\":1,\"pubkey\":\"post_author_pubkey\",\"created_at\":1234567880,\"tags\":[[\"a\",\"34550:community_creator_pubkey:bitcoin-discussion\"]],\"content\":\"This post was removed\",\"id\":\"removed_post_id\",\"sig\":\"signature\"}"
+  "content": "Removed for violating community guidelines"
 }
 ```
 

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -615,7 +615,7 @@ function PostItem({ post, communityId, isApproved, isModerator, isLastItem = fal
       await publishEvent({
         kind: KINDS.GROUP_POST_REMOVAL,
         tags: [["a", communityId], ["e", post.id], ["p", post.pubkey], ["k", String(post.kind)]],
-        content: JSON.stringify({ reason: "Removed by moderator", timestamp: Date.now(), post: post }),
+        content: "", // Empty content - do not redistribute removed content
       });
       toast.success("Post removed successfully!");
       setIsRemoveDialogOpen(false);

--- a/src/hooks/useReportActions.ts
+++ b/src/hooks/useReportActions.ts
@@ -79,7 +79,7 @@ export function useReportActions() {
                   ["p", pubkey], 
                   ["k", postKind]
                 ],
-                content: JSON.stringify(post), // Include the full post event as JSON
+                content: "", // Empty content - do not redistribute removed content
               });
               
               // Also publish a separate event with the reason if provided


### PR DESCRIPTION
The "remove post" kind was embedding the entire post to be removed in the removal event, which IMO is very bad. We should not redistribute events we are trying to remove.