### PR TITLE
Filter out unsupported kinds

### DIFF
--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -111,15 +111,15 @@ export function PostList({ communityId, showOnlyApproved = false, pendingOnly = 
           const kindTag = approval.tags.find(tag => tag[0] === "k");
           const kind = kindTag ? Number.parseInt(kindTag[1]) : null;
 
-          // Skip this approval if unsupported type
-          if (kind !== KINDS.GROUP_POST) {
+          // Skip this approval if it's for a reply (kind 1111)
+          if (kind === KINDS.GROUP_POST_REPLY) {
             return null;
           }
 
           const approvedPost = JSON.parse(approval.content) as NostrEvent;
 
-          // Skip if the post itself is a reply
-          if (approvedPost.kind === KINDS.GROUP_POST_REPLY) {
+          // Skip if the post itself is of an unsupported kind
+          if (approvedPost.kind !== KINDS.GROUP_POST) {
             return null;
           }
 


### PR DESCRIPTION
When fetching posts, it queries `KINDS.GROUP_POST`: https://github.com/andotherstuff/chorus/blob/df4600d7d67f1e2c2c05a36ae1dca67567c74fb2/src/components/groups/PostList.tsx#L179-L183

But when fetching approved posts, it doesn't check the kind of the post that has been approved:
https://github.com/andotherstuff/chorus/blob/df4600d7d67f1e2c2c05a36ae1dca67567c74fb2/src/components/groups/PostList.tsx#L119-L124

So you could end up with any random kind of post approved by another app that Chorus doesn't know how to render.

This tiny PR fixes it.
