### PR TITLE
feat: Add Japanese localization for the application

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
     <!-- Primary Meta Tags -->
-    <title>+chorus - Nostr Groups</title>
-    <meta name="title" content="+chorus - Nostr Groups">
-    <meta name="description" content="Join, create, and participate in decentralized groups powered by the Nostr protocol. Connect with communities through censorship-resistant social networking.">
+    <title>+chorus - Nostr グループ</title>
+    <meta name="title" content="+chorus - Nostr グループ">
+    <meta name="description" content="Nostrプロトコルを利用した分散型グループに参加、作成、参加しましょう。検閲に強いソーシャルネットワーキングを通じてコミュニティとつながりましょう。">
 
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -16,19 +16,19 @@
     <meta name="apple-mobile-web-app-title" content="+chorus" />
 
     <!-- Keywords -->
-    <meta name="keywords" content="nostr, groups, decentralized, social media, NIP-72, web3, pwa, progressive web app">
+    <meta name="keywords" content="nostr, グループ, 分散型, ソーシャルメディア, NIP-72, web3, pwa, プログレッシブウェブアプリ">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="+chorus - Nostr Groups">
-    <meta property="og:description" content="Join, create, and participate in decentralized groups powered by the Nostr protocol. Connect with communities through censorship-resistant social networking.">
+    <meta property="og:title" content="+chorus - Nostr グループ">
+    <meta property="og:description" content="Nostrプロトコルを利用した分散型グループに参加、作成、参加しましょう。検閲に強いソーシャルネットワーキングを通じてコミュニティとつながりましょう。">
     <meta property="og:image" content="/web-app-manifest-512x512.png">
     <meta property="og:site_name" content="+chorus">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:title" content="+chorus - Nostr Groups">
-    <meta property="twitter:description" content="Join, create, and participate in decentralized groups powered by the Nostr protocol. Connect with communities through censorship-resistant social networking.">
+    <meta property="twitter:title" content="+chorus - Nostr グループ">
+    <meta property="twitter:description" content="Nostrプロトコルを利用した分散型グループに参加、作成、参加しましょう。検閲に強いソーシャルネットワーキングを通じてコミュニティとつながりましょう。">
     <meta property="twitter:image" content="/web-app-manifest-512x512.png">
 
     <!-- PWA Manifest -->

--- a/public/About.md
+++ b/public/About.md
@@ -1,34 +1,34 @@
-# About +chorus
+# +chorusについて
 
-+chorus is a simple, decentralized space for communities to gather, share, and grow — built by the team at [And Other Stuff (AOS)](https://andotherstuff.org/) on the open [Nostr](https://github.com/nostr-protocol/nostr) protocol.
++chorusは、[And Other Stuff (AOS)](https://andotherstuff.org/) のチームがオープンな [Nostr](https://github.com/nostr-protocol/nostr) プロトコル上に構築した、コミュニティが集い、共有し、成長するためのシンプルで分散化された空間です。
 
-Whether you're organizing a movement, documenting your work, or just looking for a safe space to connect, +chorus helps you create and join groups that reflect your values — without compromising your privacy and no big tech server watching you. If you’re an activist, organizer, artist, or builder looking for a safer, simpler way to gather online, +chorus gives you the tools to do that on your terms.
+運動を組織している場合でも、仕事を記録している場合でも、あるいは単につながるための安全な空間を探している場合でも、+chorusはあなたの価値観を反映したグループを作成し、参加するのに役立ちます — プライバシーを侵害することなく、大手テック企業のサーバーに監視されることもありません。もしあなたが活動家、主催者、アーティスト、またはオンラインで集まるためのより安全でシンプルな方法を探しているビルダーなら、+chorusはあなた自身の条件でそれを行うためのツールを提供します。
 
-We give you the keys. You drive the conversation.
+私たちはあなたに鍵を渡します。あなたが会話をขับเคลื่อนします。
 
-## What can you do with +chorus?
+## +chorusで何ができますか？
 
-- Create your own group and set the tone for your community  
-- Post notes and photos — share updates, reflections, or inspiration  
-- Join conversations in public communities that align with your work  
-- Stay anonymous or show up with intention — use a pseudonym, stay private, or bring your existing Nostr identity  
-- Use it on the go — fast, lightweight, and mobile-ready  
-- Crowdfund your cause through community-driven micropayments using eCash via the [Cashu](https://cashu.space/) protocol
-- Support the voices you believe in — pay fellow contributors, reward organizers, fund projects
-- Receive support for your own work, activism, or ideas from a like-minded community
+- 独自のグループを作成し、コミュニティのトーンを設定します
+- ノートや写真を投稿 — 更新情報、考察、またはインスピレーションを共有します
+- あなたの仕事に合致するパブリックコミュニティの会話に参加します
+- 匿名を維持するか、意図を持って参加します — 仮名を使用するか、プライベートを維持するか、既存のNostrアイデンティティを持ち込みます
+- 外出先でも使用可能 — 高速、軽量、モバイル対応
+- [Cashu](https://cashu.space/) プロトコル経由のeCashを使用したコミュニティ主導のマイクロペイメントを通じて、あなたの活動目的のためにクラウドファンディングを行います
+- あなたが信じる声をサポートします — 仲間の貢献者に支払い、主催者に報酬を与え、プロジェクトに資金を提供します
+- 同じ考えを持つコミュニティから、あなた自身の仕事、活動、またはアイデアに対するサポートを受けます
 
-## About And Other Stuff (AOS)
+## And Other Stuff (AOS)について
 
-[And Other Stuff (AOS)](https://andotherstuff.org/) is the team behind +chorus.
+[And Other Stuff (AOS)](https://andotherstuff.org/) は+chorusの背後にいるチームです。
 
-We build open-source tools that help people connect, organize, and collaborate — especially for communities that need more flexible, trustworthy options. Our purpose is to support the development of open-source infrastructure, tooling, products, and related initiatives in the Nostr ecosystem that expand human agency, connection, and productivity.
+私たちは、人々がつながり、組織し、協力するのに役立つオープンソースツールを構築しています — 特に、より柔軟で信頼性の高いオプションを必要とするコミュニティのために。私たちの目的は、人間の主体性、つながり、生産性を拡大するNostrエコシステムにおけるオープンソースのインフラストラクチャ、ツール、製品、および関連イニシアチブの開発をサポートすることです。
 
-By focusing on practical, composable apps and shared infrastructure, we’re helping [Nostr](https://github.com/nostr-protocol/nostr) grow from an experimental protocol into a sustainable, widely adopted ecosystem — through collaboration, contribution, and community support.
+実用的で構成可能なアプリと共有インフラストラクチャに焦点を当てることで、私たちは協力、貢献、コミュニティサポートを通じて、[Nostr](https://github.com/nostr-protocol/nostr) が実験的なプロトコルから持続可能で広く採用されるエコシステムへと成長するのを支援しています。
 
-## Have questions?
+## ご質問はありますか？
 
-Check out our [FAQ](/faq) for answers to common questions.
+一般的な質問への回答については、[FAQ](/faq) をご覧ください。
 
-## Talk to us
+## お問い合わせ
 
-Love +chorus? Have an idea for how to make it better? Come say hello in [our group](https://chorus.community/group/34550%3A932614571afcbad4d17a191ee281e39eebbb41b93fac8fd87829622aeb112f4d%3Aand-other-stuff-mb3c9stb) or visit our [GitHub](https://github.com/andotherstuff). We welcome your feedback, ideas, contributions, and [bug reports](https://github.com/andotherstuff/chorus/issues/new).
++chorusを気に入っていただけましたか？より良くするためのアイデアはありますか？[私たちのグループ](https://chorus.community/group/34550%3A932614571afcbad4d17a191ee281e39eebbb41b93fac8fd87829622aeb112f4d%3Aand-other-stuff-mb3c9stb) で挨拶に来るか、[GitHub](https://github.com/andotherstuff) にアクセスしてください。フィードバック、アイデア、貢献、[バグレポート](https://github.com/andotherstuff/chorus/issues/new) を歓迎します。

--- a/public/faq.md
+++ b/public/faq.md
@@ -1,134 +1,134 @@
-# Frequently Asked Questions
+# よくある質問
 
-## What is +chorus?
+## +chorusとは何ですか？
 
-+chorus is a simple, decentralized space for communities to gather, share, and grow — built by the team at [And Other Stuff (AOS)](https://andotherstuff.org/) on the open [Nostr](https://github.com/nostr-protocol/nostr) protocol.
++chorusは、[And Other Stuff (AOS)](https://andotherstuff.org/) のチームがオープンな [Nostr](https://github.com/nostr-protocol/nostr) プロトコル上に構築した、コミュニティが集い、共有し、成長するためのシンプルで分散化された空間です。
 
-**You can use +chorus to create or join groups, post freely, and connect with others** — without handing over your personal data or relying on big tech.
+**+chorusを使用して、グループを作成または参加し、自由に投稿し、他の人とつながることができます** — 個人データを提供したり、大手テック企業に依存したりすることなく。
 
-Whether you're organizing a movement or supporting one, +chorus gives you the tools to do it on your terms.
+運動を組織している場合でも、支援している場合でも、+chorusはあなた自身の条件でそれを行うためのツールを提供します。
 
-**And, you can fuel your community with more than words.** Support the people and projects you care about securely and instantly, without leaving the app or adding a credit card.
+**そして、言葉以上のものでコミュニティを活性化できます。** アプリを離れたりクレジットカードを追加したりすることなく、安全かつ即座に、あなたが気にかける人々やプロジェクトをサポートします。
 
-With +chorus, we give you the keys. You drive the conversation — and the economy around it.
++chorusでは、私たちがあなたに鍵を渡します。あなたが会話を — そしてそれを取り巻く経済を — ขับเคลื่อนします。
 
-## How can I send or receive funds through +chorus?
+## +chorusを通じて資金を送受信するにはどうすればよいですか？
 
-+chorus makes it easy to support the people and projects you care about — and just as easy to receive support for your own work.
++chorusを使用すると、あなたが気にかける人々やプロジェクトを簡単にサポートでき、またあなた自身の仕事に対するサポートを簡単に受け取ることができます。
 
-You can send small, instant eCash payments to show appreciation, fund ideas, or back a cause. These payments are powered by a privacy-first system called [Cashu](https://cashu.space).
+感謝の気持ちを示したり、アイデアに資金を提供したり、大義を支援したりするために、少額のeCash支払いを即座に送信できます。これらの支払いは、[Cashu](https://cashu.space) と呼ばれるプライバシー第一のシステムによって行われます。
 
-If you're sharing your voice, leading a community, or building something meaningful, others can support you directly — right in the conversation.
+あなたが自分の声を共有したり、コミュニティを率いたり、意味のあるものを構築したりしている場合、他の人は会話の中で直接あなたをサポートできます。
 
-## Do I need a wallet to send or receive payments?
+## 支払いを行うためにウォレットは必要ですか？
 
-No wallet? No problem. Click on your screen name in the top-right corner and select **Wallet** to set up eCash. With one click, we will have you ready to send and receive funds.
+ウォレットがなくても問題ありません。画面右上のスクリーンネームをクリックし、**ウォレット** を選択してeCashを設定します。ワンクリックで、資金の送受信の準備が整います。
 
-## Do I need to create an account?
+## アカウントを作成する必要がありますか？
 
-Nope. There are no accounts to create. +chorus uses cryptographic key pairs instead of usernames and passwords.
+いいえ。作成するアカウントはありません。+chorusは、ユーザー名とパスワードの代わりに暗号鍵ペアを使用します。
 
-This means **you control your identity** — no company owns your login.
+これは、**あなたが自分のアイデンティティを管理する**ことを意味します — あなたのログイン情報を所有する会社はありません。
 
-## What is the role of group owners and moderators?
+## グループオーナーとモデレーターの役割は何ですか？
 
-**Group Owner**
+**グループオーナー**
 
-The person who creates a group automatically becomes its Owner. Owners have full administrative control, including the ability to:
-- Add or remove moderators
-- Manage group settings and permissions
-- Rename the group
-- Manage contributions to the group
+グループを作成した人は自動的にそのオーナーになります。オーナーは、以下を含む完全な管理権限を持ちます。
+- モデレーターの追加または削除
+- グループ設定と権限の管理
+- グループ名の変更
+- グループへの貢献の管理
 
-**Moderators**
+**モデレーター**
 
-Moderators help maintain a productive and respectful environment. They can:
-- Approve or remove members
-- Pin important messages
-- Enforce the group’s community guidelines
+モデレーターは、生産的で敬意のある環境を維持するのに役立ちます。彼らは次のことができます。
+- メンバーの承認または削除
+- 重要なメッセージのピン留め
+- グループのコミュニティガイドラインの施行
 
-Groups can have multiple moderators, but only one owner. Owners can promote other members to moderators at any time.
+グループには複数のモデレーターを設定できますが、オーナーは1人のみです。オーナーはいつでも他のメンバーをモデレーターに昇格させることができます。
 
-## What is a cryptographic key?
+## 暗号鍵とは何ですか？
 
-A cryptographic key is a string of characters used to secure your identity and content. Think of it like a master password that proves who you are and allows you to post, sign messages, and access your communities.
+暗号鍵は、あなたのアイデンティティとコンテンツを保護するために使用される文字列です。あなたが誰であるかを証明し、投稿、メッセージへの署名、コミュニティへのアクセスを可能にするマスターパスワードのようなものだと考えてください。
 
-- Your **public key** is like your username — others can see it. It usually starts with `npub…`
-- Your **private key** must be kept secret — it's what proves you're really you. It usually starts with `nsec…`
+- あなたの **公開鍵** はユーザー名のようなものです — 他の人が見ることができます。通常、`npub…` で始まります。
+- あなたの **秘密鍵** は秘密にしておく必要があります — それがあなたが本当にあなたであることを証明するものです。通常、`nsec…` で始まります。
 
-**If someone else gets your private key, they can act as you forever — so keep it safe.**
+**他の誰かがあなたの秘密鍵を入手すると、彼らは永久にあなたとして行動できるようになります — だから安全に保管してください。**
 
-## Can I delete my +chorus account?
+## +chorusアカウントを削除できますか？
 
-There's no traditional account to delete. Your identity on +chorus is tied to a cryptographic key.
+削除する従来のアカウントはありません。+chorusでのあなたのアイデンティティは暗号鍵に関連付けられています。
 
-If you want to stop using +chorus:
++chorusの使用をやめたい場合：
 
-- You can remove your key from your browser, extension, or device.
-- If you used a temporary key, just stop using it.
+- ブラウザ、拡張機能、またはデバイスからキーを削除できます。
+- 一時キーを使用した場合は、単にそれを使用するのをやめてください。
 
-Your content may also disappear over time if the relays you used remove old data — but this depends on each relay's policy and isn't guaranteed.
+使用したリレーが古いデータを削除した場合、あなたのコンテンツも時間とともに消える可能性がありますが、これは各リレーのポリシーに依存し、保証されていません。
 
-## Is +chorus private?
+## +chorusはプライベートですか？
 
-+chorus doesn't track you or collect personal data. You don't need an email, phone number, or name to join or post. You can use a pseudonym or stay anonymous.
++chorusはあなたを追跡したり、個人データを収集したりしません。参加したり投稿したりするために、メールアドレス、電話番号、または名前は必要ありません。仮名を使用したり、匿名のままでいることができます。
 
-However, Nostr is a public protocol — so unless you're using encrypted direct messages or private groups (which are not currently supported in +chorus), your posts are visible to anyone using a compatible app.
+ただし、Nostrは公開プロトコルです — そのため、暗号化されたダイレクトメッセージやプライベートグループ（現在+chorusではサポートされていません）を使用していない限り、あなたの投稿は互換性のあるアプリを使用している誰にでも表示されます。
 
-**Always be thoughtful about what you share.**
+**共有するものについては常に慎重に考えてください。**
 
-## Is +chorus secure?
+## +chorusは安全ですか？
 
-+chorus is designed with security by default. But because you control your keys, some of the responsibility lies with you.
++chorusはデフォルトでセキュリティを考慮して設計されています。しかし、あなたが自分のキーを管理するため、責任の一部はあなたにあります。
 
-- Your identity is tied to your **private key** (the one that starts with `nsec…`). Keep it safe and never share it.
-- If someone else gets your private key, they can impersonate you — permanently.
-- To protect your key, you can use tools like [Alby](https://getalby.com/) to log in without exposing it directly.
+- あなたのアイデンティティはあなたの **秘密鍵**（`nsec…`で始まるもの）に関連付けられています。安全に保管し、決して共有しないでください。
+- 他の誰かがあなたの秘密鍵を入手すると、彼らはあなたになりすますことができます — 永久に。
+- キーを保護するために、[Alby](https://getalby.com/) のようなツールを使用して、直接公開せずにログインすることができます。
 
-## Who can see what I post?
+## 私が投稿したものは誰が見ることができますか？
 
-+chorus groups are public communities meaning anyone using +chorus or another Nostr app can see your content.
++chorusグループはパブリックコミュニティであり、+chorusまたは別のNostrアプリを使用している誰でもあなたのコンテンツを見ることができます。
 
-Posts are stored on public relays. +chorus helps you create and manage posts and communities — it doesn't control what's stored or shared.
+投稿はパブリックリレーに保存されます。+chorusは投稿とコミュニティの作成と管理を支援します — 保存または共有されるものを制御しません。
 
-## Can I remove something I posted?
+## 投稿したものを削除できますか？
 
-You can request that relays delete your content. However, because the protocol is decentralized, content can persist if relays or users choose to keep it.
+リレーにコンテンツの削除を要求できます。ただし、プロトコルは分散化されているため、リレーまたはユーザーがそれを保持することを選択した場合、コンテンツは存続する可能性があります。
 
-## How can I access +chorus?
+## +chorusにアクセスするにはどうすればよいですか？
 
-+chorus is a browser-based app designed with mobile use in mind. No app store required — just visit the site on your phone and save to your homescreen for quick access.
++chorusは、モバイルでの使用を念頭に置いて設計されたブラウザベースのアプリです。アプリストアは必要ありません — スマートフォンでサイトにアクセスし、ホーム画面に保存してすばやくアクセスできます。
 
-## What if I'm new to Nostr?
+## Nostrを初めて使用する場合はどうすればよいですか？
 
-That's totally cool. +chorus is designed for people who have never used Nostr before. If you have a Nostr key, you can use it. If not, you can generate one in seconds.
+それは全く問題ありません。+chorusはNostrを一度も使用したことがない人向けに設計されています。Nostrキーをお持ちの場合は、それを使用できます。お持ちでない場合は、数秒で生成できます。
 
-## How can I check out the technical details?
+## 技術的な詳細を確認するにはどうすればよいですか？
 
-+chorus is an open-source project built on several key technologies:
++chorusは、いくつかの主要なテクノロジーに基づいて構築されたオープンソースプロジェクトです。
 
-**Nostr Protocol Integration**
-- Implements [NIP-72](https://github.com/nostr-protocol/nips/blob/master/72.md) for moderated communities
-- Uses [NIP-60](https://github.com/nostr-protocol/nips/blob/master/60.md) for Cashu wallet integration
-- Supports [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) for Lightning zaps
-- Implements [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) for encrypted payloads
+**Nostrプロトコル統合**
+- モデレートされたコミュニティのために [NIP-72](https://github.com/nostr-protocol/nips/blob/master/72.md) を実装
+- Cashuウォレット統合のために [NIP-60](https://github.com/nostr-protocol/nips/blob/master/60.md) を使用
+- Lightning zapsのために [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) をサポート
+- 暗号化されたペイロードのために [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) を実装
 
-**Cashu Integration**
-- Built-in Cashu wallet for instant eCash payments
-- Support for multiple Cashu mints
-- Private, non-custodial transactions
-- Encrypted transaction history
-- Automatic wallet configuration via Nostr events
+**Cashu統合**
+- 即時eCash支払い用の組み込みCashuウォレット
+- 複数のCashuミントのサポート
+- プライベートな非管理型トランザクション
+- 暗号化されたトランザクション履歴
+- Nostrイベント経由の自動ウォレット設定
 
-**Technical Stack**
-- React 18.x with TypeScript
-- TailwindCSS 3.x for styling
-- Vite for fast development
-- shadcn/ui for accessible components
-- TanStack Query for data management
+**テクニカルスタック**
+- React 18.x と TypeScript
+- スタイリングのためのTailwindCSS 3.x
+- 高速開発のためのVite
+- アクセシブルなコンポーネントのためのshadcn/ui
+- データ管理のためのTanStack Query
 
-You can explore our code, design decisions, and documentation on [GitHub](https://github.com/andotherstuff/chorus).
+私たちのコード、設計上の決定、ドキュメントは[GitHub](https://github.com/andotherstuff/chorus)で確認できます。
 
-## Something isn't working — how can I get help?
+## 何か問題が発生しています — どうすれば助けを得られますか？
 
-Feel free to ask in our [+chorus group](https://chorus.community/group/34550%3A932614571afcbad4d17a191ee281e39eebbb41b93fac8fd87829622aeb112f4d%3Aand-other-stuff-mb3c9stb), visit our [GitHub](https://github.com/andotherstuff), or check out our [website](https://andotherstuff.org). We welcome your questions, feedback, ideas, contributions, and [bug reports](https://github.com/andotherstuff/chorus/issues/new).
+私たちの[+chorusグループ](https://chorus.community/group/34550%3A932614571afcbad4d17a191ee281e39eebbb41b93fac8fd87829622aeb112f4d%3Aand-other-stuff-mb3c9stb)でお気軽にお尋ねいただくか、[GitHub](https://github.com/andotherstuff)にアクセスするか、私たちの[ウェブサイト](https://andotherstuff.org)をご確認ください。ご質問、フィードバック、アイデア、貢献、[バグレポート](https://github.com/andotherstuff/chorus/issues/new)を歓迎します。

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "chorus-nostr-groups",
-  "name": "+chorus - Nostr Groups",
+  "name": "+chorus - Nostr グループ",
   "short_name": "+chorus",
-  "description": "Join, create, and participate in decentralized groups powered by the Nostr protocol. Connect with communities through censorship-resistant social networking.",
+  "description": "Nostrプロトコルを利用した分散型グループに参加、作成、参加しましょう。検閲に強いソーシャルネットワーキングを通じてコミュニティとつながりましょう。",
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
@@ -30,21 +30,21 @@
       "sizes": "1280x720",
       "type": "image/png",
       "form_factor": "wide",
-      "label": "+chorus desktop view showing group discussions"
+      "label": "+chorus デスクトップビュー グループディスカッション表示"
     },
     {
       "src": "/screenshots/mobile.png",
       "sizes": "750x1334",
       "type": "image/png",
       "form_factor": "narrow",
-      "label": "+chorus mobile view for group chat"
+      "label": "+chorus モバイルビュー グループチャット用"
     }
   ],
   "shortcuts": [
     {
-      "name": "New Group",
-      "short_name": "New Group",
-      "description": "Create a new decentralized group",
+      "name": "新しいグループ",
+      "short_name": "新しいグループ",
+      "description": "新しい分散型グループを作成する",
       "url": "/groups/new",
       "icons": [
         {
@@ -54,9 +54,9 @@
       ]
     },
     {
-      "name": "Notifications",
-      "short_name": "Notifications",
-      "description": "View your notifications",
+      "name": "お知らせ",
+      "short_name": "お知らせ",
+      "description": "お知らせを見る",
       "url": "/notifications",
       "icons": [
         {

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -34,7 +34,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     setIsLoading(true);
     try {
       if (!('nostr' in window)) {
-        throw new Error('Nostr extension not found. Please install a NIP-07 extension.');
+        throw new Error('Nostr拡張機能が見つかりません。NIP-07拡張機能をインストールしてください。');
       }
       const loginInfo = await login.extension();
       
@@ -104,16 +104,16 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className='sm:max-w-md p-0 overflow-hidden rounded-2xl'>
         <DialogHeader className='px-6 pt-6 pb-0 relative'>
-          <DialogTitle className='text-xl font-semibold text-center'>Log in</DialogTitle>
+          <DialogTitle className='text-xl font-semibold text-center'>ログイン</DialogTitle>
           <DialogDescription className='text-center text-muted-foreground mt-2'>
-            Access your account securely with your preferred method
+            ご希望の方法でアカウントに安全にアクセスしてください
           </DialogDescription>
         </DialogHeader>
 
         <div className='px-6 py-8 space-y-6'>
           <Tabs defaultValue={'nostr' in window ? 'extension' : 'key'} className='w-full'>
             <TabsList className='grid grid-cols-3 mb-6'>
-              <TabsTrigger value='extension'>Extension</TabsTrigger>
+              <TabsTrigger value='extension'>拡張機能</TabsTrigger>
               <TabsTrigger value='key'>Nsec</TabsTrigger>
               <TabsTrigger value='bunker'>Bunker</TabsTrigger>
             </TabsList>
@@ -122,14 +122,14 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
               <div className='text-center p-4 rounded-lg bg-muted'>
                 <Shield className='w-12 h-12 mx-auto mb-3 text-primary' />
                 <div className='text-sm text-muted-foreground mb-4'>
-                  Login with one click using the browser extension
+                  ブラウザ拡張機能を使用してワンクリックでログインします
                 </div>
                 <Button
                   className='w-full rounded-full py-6'
                   onClick={handleExtensionLogin}
                   disabled={isLoading}
                 >
-                  {isLoading ? 'Logging in...' : 'Login with Extension'}
+                  {isLoading ? 'ログイン中...' : '拡張機能でログイン'}
                 </Button>
               </div>
             </TabsContent>
@@ -138,7 +138,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
               <div className='space-y-4'>
                 <div className='space-y-2'>
                   <label htmlFor='nsec' className='text-sm font-medium text-foreground'>
-                    Enter your nsec
+                    nsecを入力してください
                   </label>
                   <Input
                     id='nsec'
@@ -150,7 +150,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                 </div>
 
                 <div className='text-center'>
-                  <div className='text-sm mb-2 text-muted-foreground'>Or upload a key file</div>
+                  <div className='text-sm mb-2 text-muted-foreground'>またはキーファイルをアップロード</div>
                   <input
                     type='file'
                     accept='.txt'
@@ -164,7 +164,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                     onClick={() => fileInputRef.current?.click()}
                   >
                     <Upload className='w-4 h-4 mr-2' />
-                    Upload Nsec File
+                    Nsecファイルをアップロード
                   </Button>
                 </div>
 
@@ -173,7 +173,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                   onClick={handleKeyLogin}
                   disabled={isLoading || !nsec.trim()}
                 >
-                  {isLoading ? 'Verifying...' : 'Login with Nsec'}
+                  {isLoading ? '検証中...' : 'Nsecでログイン'}
                 </Button>
               </div>
             </TabsContent>
@@ -191,7 +191,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                   placeholder='bunker://'
                 />
                 {bunkerUri && !bunkerUri.startsWith('bunker://') && (
-                  <div className='text-destructive text-xs'>URI must start with bunker://</div>
+                  <div className='text-destructive text-xs'>URIはbunker://で始まる必要があります</div>
                 )}
               </div>
 
@@ -200,7 +200,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                 onClick={handleBunkerLogin}
                 disabled={isLoading || !bunkerUri.trim() || !bunkerUri.startsWith('bunker://')}
               >
-                {isLoading ? 'Connecting...' : 'Login with Bunker'}
+                {isLoading ? '接続中...' : 'Bunkerでログイン'}
               </Button>
             </TabsContent>
           </Tabs>

--- a/src/components/groups/CreatePostForm.tsx
+++ b/src/components/groups/CreatePostForm.tsx
@@ -129,7 +129,7 @@ export function CreatePostForm({ communityId, onPostSuccess }: CreatePostFormPro
 
     } catch (error) {
       console.error('Error accessing microphone:', error);
-      toast.error('Could not access microphone. Please check permissions.');
+      toast.error('マイクにアクセスできませんでした。権限を確認してください。');
     }
   };
 
@@ -181,14 +181,14 @@ export function CreatePostForm({ communityId, onPostSuccess }: CreatePostFormPro
 
   const handleSubmit = async () => {
     if (!content.trim() && !mediaFile) {
-      toast.error("Please enter some content or add media");
+      toast.error("コンテンツを入力するか、メディアを追加してください");
       return;
     }
 
     try {
       const parsedId = parseNostrAddress(communityId);
       if (!parsedId) {
-        toast.error("Invalid group ID");
+        toast.error("無効なグループID");
         return;
       }
 
@@ -233,7 +233,7 @@ ${mediaUrl}`;
       setMediaFile(null);
       setPreviewUrl(null);
 
-      toast.success("Post published successfully!");
+      toast.success("投稿が正常に公開されました！");
       
       // Call the onPostSuccess callback if provided
       if (onPostSuccess) {
@@ -241,7 +241,7 @@ ${mediaUrl}`;
       }
     } catch (error) {
       console.error("Error publishing post:", error);
-      toast.error("Failed to publish post. Please try again.");
+      toast.error("投稿の公開に失敗しました。もう一度お試しください。");
     }
   };
 
@@ -258,7 +258,7 @@ ${mediaUrl}`;
 
           <div className="flex-1">
             <Textarea
-              placeholder={`What's on your mind, ${displayName.split(' ')[0]}?`}
+              placeholder={`何を考えていますか、${displayName.split(' ')[0]}さん？`}
               value={content}
               onChange={(e) => setContent(e.target.value)}
               className="min-h-20 resize-none p-2"
@@ -280,9 +280,9 @@ ${mediaUrl}`;
                           <Mic className="h-5 w-5 text-green-600" />
                         </div>
                         <div className="flex-1">
-                          <div className="text-sm font-medium">Voice Recording</div>
+                          <div className="text-sm font-medium">音声録音</div>
                           <div className="text-xs text-muted-foreground">
-                            Ready to send • {(mediaFile.size / 1024).toFixed(0)} KB
+                            送信準備完了 • {(mediaFile.size / 1024).toFixed(0)} KB
                           </div>
                         </div>
                       </>
@@ -291,7 +291,7 @@ ${mediaUrl}`;
                         <div className="flex-1">
                           <div className="text-sm font-medium">{mediaFile.name}</div>
                           <div className="text-xs text-muted-foreground">
-                            Audio file • {(mediaFile.size / 1024).toFixed(0)} KB
+                            音声ファイル • {(mediaFile.size / 1024).toFixed(0)} KB
                           </div>
                         </div>
                         <audio
@@ -339,7 +339,7 @@ ${mediaUrl}`;
           <Button variant="ghost" size="sm" className="text-muted-foreground h-8 px-2 text-xs" asChild>
             <label htmlFor="media-upload" className="cursor-pointer flex items-center">
               <Image className="h-3.5 w-3.5 mr-1" />
-              Media
+              メディア
               <input
                 id="media-upload"
                 type="file"
@@ -366,7 +366,7 @@ ${mediaUrl}`;
             ) : (
               <>
                 <Mic className="h-3.5 w-3.5 mr-1" />
-                Record
+                録音
               </>
             )}
           </Button>
@@ -381,12 +381,12 @@ ${mediaUrl}`;
           {isPublishing || isUploading ? (
             <>
               <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-              Posting...
+              投稿中...
             </>
           ) : (
             <>
               <Send className="h-3.5 w-3.5 mr-1.5" />
-              Post
+              投稿
             </>
           )}
         </Button>

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -47,7 +47,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
                 transition-all flex items-center`}
             >
               <Icon name="Home" size={16} className="mr-1" />
-              <span className="hidden sm:inline">Groups</span>
+              <span className="hidden sm:inline">グループ</span>
             </Link>
             <Link 
               to="/feed" 
@@ -57,7 +57,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
                 transition-all flex items-center`}
             >
               <Icon name="Feed" size={16} className="mr-1" />
-              <span className="hidden sm:inline">Feed</span>
+              <span className="hidden sm:inline">フィード</span>
             </Link>
           </div>
         )}

--- a/src/pages/Groups.tsx
+++ b/src/pages/Groups.tsx
@@ -301,7 +301,7 @@ export default function Groups() {
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
               >
                 <TrendingUp className="w-3.5 h-3.5" />
-                Trending Hashtags
+                トレンドハッシュタグ
               </a>
             </div>
           </div>
@@ -311,7 +311,7 @@ export default function Groups() {
               className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
             >
               <TrendingUp className="w-3.5 h-3.5" />
-              Trending Hashtags
+              トレンドハッシュタグ
             </a>
           </div>
         </div>
@@ -362,21 +362,21 @@ export default function Groups() {
           ) : searchQuery ? (
             <div className="col-span-full text-center py-10">
               <h2 className="text-xl font-semibold mb-2">
-                No matching groups found
+                一致するグループが見つかりません
               </h2>
               <p className="text-muted-foreground">
-                Try a different search term or browse all groups
+                別の検索語を試すか、すべてのグループを閲覧してください
               </p>
             </div>
           ) : (
             <div className="col-span-full text-center py-10">
-              <h2 className="text-xl font-semibold mb-2">No groups found</h2>
+              <h2 className="text-xl font-semibold mb-2">グループが見つかりません</h2>
               <p className="text-muted-foreground mb-4">
-                Be the first to create a group on this platform!
+                このプラットフォームで最初にグループを作成しましょう！
               </p>
               {!user && (
                 <p className="text-sm text-muted-foreground">
-                  Please log in to create a group
+                  グループを作成するにはログインしてください
                 </p>
               )}
             </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -86,8 +86,8 @@ const Index = () => {
 
           // Show notification with animated icon
           toast({
-            title: "✅ Ecash waiting for you!",
-            description: `Complete signup to receive ${displayAmount} in your wallet`,
+            title: "✅ eキャッシュがあなたを待っています！",
+            description: `サインアップを完了して、ウォレットで${displayAmount}を受け取ります`,
           });
 
           // Mark as processed
@@ -164,8 +164,8 @@ const Index = () => {
       setNewUser(true); // Mark as new user
     } catch (e) {
       toast({
-        title: "Error",
-        description: "Failed to create account. Please try again.",
+        title: "エラー",
+        description: "アカウントの作成に失敗しました。もう一度お試しください。",
         variant: "destructive",
       });
     } finally {
@@ -187,7 +187,7 @@ const Index = () => {
             <h1 className="text-4xl font-extralight mb-4">
               <div className="flex flex-row items-baseline justify-center flex-wrap">
                 <span className="font-extralight mr-2 whitespace-nowrap">
-                  welcome to
+                  へようこそ
                 </span>
                 <div className="flex flex-row items-baseline">
                   <span className="text-red-500 font-extrabold">+</span>
@@ -198,7 +198,7 @@ const Index = () => {
               </div>
             </h1>
             <div className="text-lg text-muted-foreground font-extralight">
-              public/private groups are money
+              公開/非公開グループが収益を生みます
             </div>
           </div>
           <Button
@@ -207,17 +207,17 @@ const Index = () => {
             disabled={creating}
             className="w-full max-w-[200px] flex items-center justify-center gap-2 mb-6"
           >
-            {creating ? "Creating..." : "Get Started"}
+            {creating ? "作成中..." : "始める"}
           </Button>
           <div className="text-sm text-muted-foreground flex items-center justify-center mt-3">
-            <span>Have a Nostr/+chorus account?</span>&nbsp;
+            <span>Nostr/+chorusアカウントをお持ちですか？</span>&nbsp;
             <Button
               variant="link"
               size="sm"
               className="text-primary font-medium hover:underline p-0 h-auto"
               onClick={() => setLoginOpen(true)}
             >
-              Sign in
+              サインイン
             </Button>
           </div>
 
@@ -227,11 +227,11 @@ const Index = () => {
               <div className="flex items-center justify-center gap-2 mb-2">
                 <Smartphone className="w-4 h-4 text-muted-foreground" />
                 <span className="text-sm font-medium text-muted-foreground">
-                  Get the App
+                  アプリを入手
                 </span>
               </div>
               <p className="text-xs text-muted-foreground mb-3">
-                Install +chorus for the best experience
+                +chorusをインストールして最高の体験を
               </p>
               <PWAInstallButton
                 variant="outline"
@@ -272,10 +272,10 @@ const Index = () => {
         <div className="min-h-screen flex flex-col items-center justify-center bg-background dark:bg-dark-background">
           <div className="w-full max-w-lg mx-auto p-8">
             <h2 className="text-2xl font-bold mb-4 text-center">
-              Set your name and pic
+              名前と画像を設定
             </h2>
             <p className="text-gray-600 mb-6 text-center">
-              You can always update them later.
+              後でいつでも更新できます。
             </p>
             <EditProfileForm showSkipLink={true} initialName={generatedName} />
           </div>
@@ -287,7 +287,7 @@ const Index = () => {
   // Fallback (should redirect to /groups in most cases)
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground">
-      <div>Loading groups...</div>
+      <div>グループを読み込み中...</div>
     </div>
   );
 };


### PR DESCRIPTION
This commit introduces Japanese translations for various parts of the +chorus application.

Key areas translated:
- `index.html`: Translated metadata including title, description, and keywords.
- `public/manifest.json`: Translated PWA manifest details like name, description, shortcut names, and screenshot labels.
- `public/About.md`: Translated the entire About page content.
- `public/faq.md`: Translated the entire FAQ page content.
- UI Components (`src/components`): Translated text in Header, LoginDialog, and CreatePostForm. This includes button labels, placeholders, dialog messages, and toast notifications.
- Pages (`src/pages`): Translated text on the Index page (welcome messages, onboarding prompts, PWA install prompts) and Groups page (section titles, empty state messages).

The translation aims to make the application accessible to Japanese-speaking users. User-facing strings were directly replaced in the codebase as there is no existing i18n framework. Brand names and technical terms like '+chorus', 'Nostr', 'Nsec', 'Bunker', 'Cashu' were generally kept in English to maintain consistency and technical accuracy.