### PR TITLE
fix/428-owner-mods-posts-should-be-considered-approved-even-if-not-added-as-member

### DIFF
--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -404,18 +404,20 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
     }).filter(Boolean);
 
     // Filter posts based on approval status
-    let filteredPostsWithApproval = postsWithApproval;
-    if (showOnlyApproved) {
-      filteredPostsWithApproval = postsWithApproval.filter(post => 'approval' in post);
-    } else if (pendingOnly) {
-      filteredPostsWithApproval = postsWithApproval.filter(post => {
-        // If it has an approval property, it's either manually approved or auto-approved
-        if ('approval' in post) {
-          return false;
-        }
-        return true;
-      });
-    }
+    const filteredPostsWithApproval = (() => {
+      if (showOnlyApproved) {
+        return postsWithApproval.filter(post => 'approval' in post);
+      } else if (pendingOnly) {
+        return postsWithApproval.filter(post => {
+          // If it has an approval property, it's either manually approved or auto-approved
+          if ('approval' in post) {
+            return false;
+          }
+          return true;
+        });
+      }
+      return postsWithApproval; 
+    })();
 
     // Sort all posts by creation time (pinned posts will naturally be at the top due to their IDs)
     return filteredPostsWithApproval.sort((a, b) => 

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -342,24 +342,7 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
       if (isNestedReply) return post;
     }
 
-    // For legacy kind 11 posts, they are always considered top-level
-    // Auto-approve for approved members, moderators, and the community owner
-    const isApprovedMember = approvedMembers.includes(post.pubkey);
-    const isModerator = moderators.includes(post.pubkey);
-    const isOwner = communityEvent && post.pubkey === communityEvent.pubkey;
-    const isApproved = isApprovedMember || isModerator || isOwner
-
-    return {
-      ...post,
-      ...(isApproved ? { approval: {
-          id: `auto-approved-${post.id}`,
-          pubkey: post.pubkey,
-          created_at: post.created_at,
-          autoApproved: true,
-          kind: post.kind
-        }
-      } : {})
-    };
+    return post;
   }).filter(Boolean);
 
   // Count approved and pending posts
@@ -384,63 +367,60 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
 
   // Memoize the sorted posts to avoid unnecessary re-renders
   const sortedPosts = useMemo(() => {
-    // Process pinned posts through the same approval logic
     const pinnedPostsProcessed = (pinnedPosts || [])
       .filter(post => 
         !removedPostIds.includes(post.id) && 
         !bannedUsers.includes(post.pubkey)
       )
-      .map(post => {
-        // Check if this pinned post is already in the approved posts
-        const existingApproval = (approvedPosts || []).find(ap => ap.id === post.id);
-        if (existingApproval) {
-          return existingApproval;
-        }
+    // Combine all posts and apply approval logic once
+    const allPosts = [
+      ...filteredPosts,
+      ...pinnedPostsProcessed
+    ];
 
-        // Auto-approve for approved members, moderators, and the community owner
-        const isApprovedMember = approvedMembers.includes(post.pubkey);
-        const isModerator = moderators.includes(post.pubkey);
-        const isOwner = communityEvent && post.pubkey === communityEvent.pubkey;
-        const isApproved = isApprovedMember || isModerator || isOwner
-        
-        return {
-          ...post,
-          ...(isApproved ? { approval: {
-              id: `auto-approved-${post.id}`,
-              pubkey: post.pubkey,
-              created_at: post.created_at,
-              autoApproved: true,
-              kind: post.kind
-            }
-          } : {})
-        };
-      });
+    // Apply approval logic to all posts
+    const postsWithApproval = allPosts.map(post => {
+      if (!post) return post;
+      
+      // If post already has approval info, return it as is
+      if ('approval' in post) return post;
 
-    // Filter pinned posts based on approval status
-    let filteredPinnedPosts = pinnedPostsProcessed;
+      // Auto-approve for approved members, moderators, and the community owner
+      const isApprovedMember = approvedMembers.includes(post.pubkey);
+      const isModerator = moderators.includes(post.pubkey);
+      const isOwner = communityEvent && post.pubkey === communityEvent.pubkey;
+      const isApproved = isApprovedMember || isModerator || isOwner;
+      
+      return {
+        ...post,
+        ...(isApproved ? { approval: {
+          id: `auto-approved-${post.id}`,
+          pubkey: post.pubkey,
+          created_at: post.created_at,
+          autoApproved: true,
+          kind: post.kind
+        }} : {})
+      };
+    });
+
+    // Filter posts based on approval status
+    let filteredPostsWithApproval = postsWithApproval;
     if (showOnlyApproved) {
-      filteredPinnedPosts = pinnedPostsProcessed.filter(post => 'approval' in post);
+      filteredPostsWithApproval = postsWithApproval.filter(post => 'approval' in post);
     } else if (pendingOnly) {
-      filteredPinnedPosts = pinnedPostsProcessed.filter(post => !('approval' in post));
+      filteredPostsWithApproval = postsWithApproval.filter(post => {
+        // If it has an approval property, it's either manually approved or auto-approved
+        if ('approval' in post) {
+          return false;
+        }
+        return true;
+      });
     }
 
-    // Separate regular posts (excluding pinned ones)
-    const regularPosts = filteredPosts.filter(post => 
-      post && !pinnedPostIds.includes(post.id)
-    );
-
-    // Sort regular posts by creation time
-    const sortedRegularPosts = regularPosts.sort((a, b) => 
+    // Sort all posts by creation time (pinned posts will naturally be at the top due to their IDs)
+    return filteredPostsWithApproval.sort((a, b) => 
       (b?.created_at || 0) - (a?.created_at || 0)
     );
-    
-    // Sort pinned posts by creation time (most recent pins first)
-    const sortedPinnedPosts = filteredPinnedPosts.sort((a, b) => 
-      (b?.created_at || 0) - (a?.created_at || 0)
-    );
-
-    // Combine pinned posts first, then regular posts
-    return [...sortedPinnedPosts, ...sortedRegularPosts];
   }, [
     pinnedPosts, 
     removedPostIds, 

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -413,7 +413,7 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
       return postsWithApproval; 
     })();
 
-    // Sort all posts by creation time (pinned posts will naturally be at the top due to their IDs)
+    // Sort all posts by creation time
     return filteredPostsWithApproval.sort((a, b) => 
       (b?.created_at || 0) - (a?.created_at || 0)
     );

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -401,7 +401,7 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
           kind: post.kind
         }} : {})
       };
-    });
+    }).filter(Boolean);
 
     // Filter posts based on approval status
     let filteredPostsWithApproval = postsWithApproval;

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -383,7 +383,7 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
       if (!post) return post;
       
       // If post already has approval info, return it as is
-      if ('approval' in post) return post;
+      if (!!post?.approval) return post;
 
       // Auto-approve for approved members, moderators, and the community owner
       const isApprovedMember = approvedMembers.includes(post.pubkey);
@@ -406,15 +406,9 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
     // Filter posts based on approval status
     const filteredPostsWithApproval = (() => {
       if (showOnlyApproved) {
-        return postsWithApproval.filter(post => 'approval' in post);
+        return postsWithApproval.filter(post => !!post?.approval);
       } else if (pendingOnly) {
-        return postsWithApproval.filter(post => {
-          // If it has an approval property, it's either manually approved or auto-approved
-          if ('approval' in post) {
-            return false;
-          }
-          return true;
-        });
+        return postsWithApproval.filter(post => !post?.approval);
       }
       return postsWithApproval; 
     })();

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -347,19 +347,19 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
     const isApprovedMember = approvedMembers.includes(post.pubkey);
     const isModerator = moderators.includes(post.pubkey);
     const isOwner = communityEvent && post.pubkey === communityEvent.pubkey;
-    if (isApprovedMember || isModerator || isOwner) {
-      return {
-        ...post,
-        approval: {
+    const isApproved = isApprovedMember || isModerator || isOwner
+
+    return {
+      ...post,
+      ...(isApproved ? { approval: {
           id: `auto-approved-${post.id}`,
           pubkey: post.pubkey,
           created_at: post.created_at,
           autoApproved: true,
           kind: post.kind
         }
-      };
-    }
-    return post;
+      } : {})
+    };
   }).filter(Boolean);
 
   // Count approved and pending posts
@@ -398,22 +398,22 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
         }
 
         // Auto-approve for approved members, moderators, and the community owner
-         const isApprovedMember = approvedMembers.includes(post.pubkey);
-         const isModerator = moderators.includes(post.pubkey);
-         const isOwner = communityEvent && post.pubkey === communityEvent.pubkey;
-         if (isApprovedMember || isModerator || isOwner) {
-          return {
-            ...post,
-            approval: {
+        const isApprovedMember = approvedMembers.includes(post.pubkey);
+        const isModerator = moderators.includes(post.pubkey);
+        const isOwner = communityEvent && post.pubkey === communityEvent.pubkey;
+        const isApproved = isApprovedMember || isModerator || isOwner
+        
+        return {
+          ...post,
+          ...(isApproved ? { approval: {
               id: `auto-approved-${post.id}`,
               pubkey: post.pubkey,
               created_at: post.created_at,
               autoApproved: true,
               kind: post.kind
             }
-          };
-        }
-        return post;
+          } : {})
+        };
       });
 
     // Filter pinned posts based on approval status

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -343,10 +343,11 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
     }
 
     // For legacy kind 11 posts, they are always considered top-level
-    // Auto-approve for approved members and moderators
+    // Auto-approve for approved members, moderators, and the community owner
     const isApprovedMember = approvedMembers.includes(post.pubkey);
     const isModerator = moderators.includes(post.pubkey);
-    if (isApprovedMember || isModerator) {
+    const isOwner = communityEvent && post.pubkey === communityEvent.pubkey;
+    if (isApprovedMember || isModerator || isOwner) {
       return {
         ...post,
         approval: {
@@ -396,10 +397,11 @@ export function PostList({ communityId, showOnlyApproved = true, pendingOnly = f
           return existingApproval;
         }
 
-        // Auto-approve for approved members and moderators
-        const isApprovedMember = approvedMembers.includes(post.pubkey);
-        const isModerator = moderators.includes(post.pubkey);
-        if (isApprovedMember || isModerator) {
+        // Auto-approve for approved members, moderators, and the community owner
+         const isApprovedMember = approvedMembers.includes(post.pubkey);
+         const isModerator = moderators.includes(post.pubkey);
+         const isOwner = communityEvent && post.pubkey === communityEvent.pubkey;
+         if (isApprovedMember || isModerator || isOwner) {
           return {
             ...post,
             approval: {


### PR DESCRIPTION
closes #428 

- Now comments/notes from the creator of the community are shown as approved in the UI as standard. 
- I also refactored the list of notes/comments, specifically combining them, so that this approval is done in one place only